### PR TITLE
Detecting Transaction Examples

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "jscoverage": "^0.6.0",
     "mocha": "^2.3.4",
     "mocha-lcov-reporter": "^1.0.0",
-    "protagonist": "^1.3.0-pre.0"
+    "protagonist": "^1.3.0-pre.1"
   },
   "keywords": [
     "api",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "clone": "^1.0.2",
+    "traverse": "^0.6.6",
     "uri-template": "^1.0.0"
   },
   "devDependencies": {

--- a/src/detect-transaction-examples.coffee
+++ b/src/detect-transaction-examples.coffee
@@ -1,0 +1,116 @@
+
+traverse = require 'traverse'
+
+
+detectTransactionExamples = (transition) ->
+  # Index of requests and responses within given *transition*, sorted by
+  # their position in the original API Blueprint document.
+  index = createIndex transition
+
+  # Iterating over requests and responses in the index, keeping track of in
+  # which block we currently are (block of requests: 'req', block
+  # of responses: 'res'). In case there's change 'res' -> 'req', we raise
+  # the example number. The example number is then attached to every
+  # transaction as a Refract attribute.
+  example = 1
+  state = 'req'
+
+  for {type, transaction} in index
+    if type is 'httpRequest'
+      example += 1 if state is 'res'
+      state = 'req'
+    else # 'httpResponse'
+      state = 'res'
+
+    transaction.attributes ?= {}
+    transaction.attributes.example = example
+
+
+# Provides index of requests and responses within given *transition*, sorted by
+# their position in the original API Blueprint document (from first to last).
+#
+#     [
+#         {
+#             'type': 'httpResponse',
+#             'transaction': {'element': 'httpTransaction', ...},
+#             'position': 85,
+#         },
+#         ...
+#     ]
+#
+# ## Index Entry (object)
+#
+# - type: httpRequest, httpResponse (enum)
+# - transaction (object) - Parent transaction element.
+# - position (number) - Position of the first character relevant to
+#   the request (or response) within the original API Blueprint document.
+createIndex = (transition) ->
+  mapping = {}
+
+  traversal = traverse transition
+  traversal.forEach (node) ->
+    # Process just sourceMap elements.
+    return unless node.element is 'sourceMap'
+
+    # Ignore sourceMap elements for request's HTTP method. Method is
+    # often on a different place in the document than the actual
+    # request is, so it's sourceMap is misleading for our purpose.
+    return if 'method' in @path
+
+    # Iterate over parents of the source map element and find
+    # corresponding request (or response) and transaction elements.
+    #
+    # Key is a string representing one request or response in the index.
+    # It is a path of the request (or response), concatenated by dots.
+    key = null
+    entry = {}
+
+    for i in [0..@path.length]
+      path = @path[0..i]
+      parentNode = traversal.get path
+      switch parentNode.element
+        when 'httpRequest', 'httpResponse'
+          key = path.join '.'
+          entry.type = parentNode.element
+        when 'httpTransaction'
+          entry.transaction = parentNode
+
+    # Process just sourceMap elements inside requests and responses.
+    #
+    # If we were not able to determine all necessary information (e.g. because
+    # given source map isn't inside request or response, but somewhere else
+    # in the transition's Refract tree), ignore the node.
+    return unless key and entry.type and entry.transaction
+
+    # Take positions of the first character for each continuous code block
+    # in the source map.
+    #
+    # At the end we'll take the lowest number from the array as a representation
+    # of the beginning of the whole request (or response) within the original
+    # document.
+    positions = (charBlock[0] for charBlock in node.content)
+
+    if mapping[key]
+      # If entry for given request (or response) already exists, add
+      # also its current position to the array. This allows us to take the
+      # lowest number among all source maps for given request (or response).
+      positions.push mapping[key].position
+    else
+      # If the entry isn't in the mapping yet, create a new one.
+      mapping[key] ?= entry
+
+    # Now set the lowest position from all positions found for
+    # the request (or response). This way at the end of this traversal
+    # the 'position' attribute should contain position of the first
+    # character relevant for the whole request (or response).
+    mapping[key].position = Math.min.apply null, positions
+
+    return # needed for 'traverse' to work properly in CoffeeScript
+
+  # Turn the mapping into an index, i.e. an array sorted by position.
+  index = (entry for own key, entry of mapping)
+  index.sort (entry1, entry2) -> entry1.position - entry2.position
+  return index
+
+
+module.exports = detectTransactionExamples

--- a/src/detect-transaction-examples.coffee
+++ b/src/detect-transaction-examples.coffee
@@ -1,11 +1,11 @@
 
-traverse = require 'traverse'
+traverse = require('traverse')
 
 
 detectTransactionExamples = (transition) ->
   # Index of requests and responses within given *transition*, sorted by
   # their position in the original API Blueprint document.
-  index = createIndex transition
+  index = createIndex(transition)
 
   # Iterating over requests and responses in the index, keeping track of in
   # which block we currently are (block of requests: 'req', block
@@ -47,8 +47,8 @@ detectTransactionExamples = (transition) ->
 createIndex = (transition) ->
   mapping = {}
 
-  traversal = traverse transition
-  traversal.forEach (node) ->
+  traversal = traverse(transition)
+  traversal.forEach((node) ->
     # Process just sourceMap elements.
     return unless node.element is 'sourceMap'
 
@@ -67,10 +67,10 @@ createIndex = (transition) ->
 
     for i in [0..@path.length]
       path = @path[0..i]
-      parentNode = traversal.get path
+      parentNode = traversal.get(path)
       switch parentNode.element
         when 'httpRequest', 'httpResponse'
-          key = path.join '.'
+          key = path.join('.')
           entry.type = parentNode.element
         when 'httpTransaction'
           entry.transaction = parentNode
@@ -85,16 +85,16 @@ createIndex = (transition) ->
     # Take positions of the first character for each continuous code block
     # in the source map.
     #
-    # At the end we'll take the lowest number from the array as a representation
-    # of the beginning of the whole request (or response) within the original
-    # document.
+    # At the end we'll take the lowest number from the array as
+    # a representation of the beginning of the whole request (or response)
+    # within the original document.
     positions = (charBlock[0] for charBlock in node.content)
 
     if mapping[key]
       # If entry for given request (or response) already exists, add
       # also its current position to the array. This allows us to take the
       # lowest number among all source maps for given request (or response).
-      positions.push mapping[key].position
+      positions.push(mapping[key].position)
     else
       # If the entry isn't in the mapping yet, create a new one.
       mapping[key] ?= entry
@@ -103,13 +103,14 @@ createIndex = (transition) ->
     # the request (or response). This way at the end of this traversal
     # the 'position' attribute should contain position of the first
     # character relevant for the whole request (or response).
-    mapping[key].position = Math.min.apply null, positions
+    mapping[key].position = Math.min.apply(null, positions)
 
     return # needed for 'traverse' to work properly in CoffeeScript
+  )
 
   # Turn the mapping into an index, i.e. an array sorted by position.
   index = (entry for own key, entry of mapping)
-  index.sort (entry1, entry2) -> entry1.position - entry2.position
+  index.sort((entry1, entry2) -> entry1.position - entry2.position)
   return index
 
 

--- a/test/unit/detect-transaction-examples-test.coffee
+++ b/test/unit/detect-transaction-examples-test.coffee
@@ -1,15 +1,15 @@
 
-{assert} = require 'chai'
-protagonist = require 'protagonist'
+{assert} = require('chai')
+protagonist = require('protagonist')
 
-detectTransactionExamples = require '../../src/detect-transaction-examples'
+detectTransactionExamples = require('../../src/detect-transaction-examples')
 
 
 # Encapsulates a single test scenario.
 scenario = (description, {actionContent, examples, exampleNumbersPerTransaction, skip}) ->
   return if skip
 
-  describe "#{description}", ->
+  describe("#{description}", ->
     apiBlueprint = """
       FORMAT: 1A
       # Gargamel API
@@ -21,52 +21,65 @@ scenario = (description, {actionContent, examples, exampleNumbersPerTransaction,
     action = undefined # API Blueprint AST
     transition = undefined # API Elements (a.k.a. Refract)
 
-    beforeEach (done) ->
+    beforeEach((done) ->
       options = {type: 'ast', generateSourceMap: true}
-      protagonist.parse apiBlueprint, options, (err, parseResult) ->
-        return done err if err
+      protagonist.parse(apiBlueprint, options, (err, parseResult) ->
+        return done(err) if err
         action = parseResult.ast.resourceGroups[0].resources[0].actions[0]
         done()
+      )
+    )
 
-    beforeEach (done) ->
+    beforeEach((done) ->
       options = {type: 'refract', generateSourceMap: true}
-      protagonist.parse apiBlueprint, options, (err, parseResult) ->
-        return done err if err
+      protagonist.parse(apiBlueprint, options, (err, parseResult) ->
+        return done(err) if err
         transition = parseResult.content[0].content[0].content[0].content[0]
         done()
+      )
+    )
 
-    beforeEach ->
-      detectTransactionExamples transition
+    beforeEach( ->
+      detectTransactionExamples(transition)
+    )
 
-    it 'transactions got expected example numbers', ->
+    it('transactions got expected example numbers', ->
       expected = []
       for example, exampleIndex in action.examples
         for requestIndex in [0...(example.requests.length or 1)]
           for responseIndex in [0...(example.responses.length or 1)]
-            expected.push exampleIndex + 1
+            expected.push(exampleIndex + 1)
 
-      assert.deepEqual expected, (trans.attributes?.example for trans in transition.content)
+      assert.deepEqual(
+        expected,
+        (trans.attributes?.example for trans in transition.content)
+      )
+    )
+  )
 
 
-describe 'detectTransactionExamples()', ->
-  describe 'various combinations of requests and responses', ->
-    scenario 'empty action',
+describe('detectTransactionExamples()', ->
+  describe('various combinations of requests and responses', ->
+    scenario('empty action',
       actionContent: ''
       exampleNumbersPerTransaction: []
+    )
 
-    scenario 'single request',
+    scenario('single request',
       actionContent: '''
         + Request (application/json)
       '''
       exampleNumbersPerTransaction: [1]
+    )
 
-    scenario 'single response',
+    scenario('single response',
       actionContent: '''
         + Response 200
       '''
       exampleNumbersPerTransaction: [1]
+    )
 
-    scenario 'single response followed by another example',
+    scenario('single response followed by another example',
       actionContent: '''
         + Response 200
 
@@ -74,8 +87,9 @@ describe 'detectTransactionExamples()', ->
         + Response 200
       '''
       exampleNumbersPerTransaction: [1, 2]
+    )
 
-    scenario 'single response followed by a single request-response pair',
+    scenario('single response followed by a single request-response pair',
       actionContent: '''
         + Response 200
 
@@ -83,15 +97,17 @@ describe 'detectTransactionExamples()', ->
         + Response 200
       '''
       exampleNumbersPerTransaction: [1, 2]
+    )
 
-    scenario 'single request-response pair',
+    scenario('single request-response pair',
       actionContent: '''
         + Request (application/json)
         + Response 200
       '''
       exampleNumbersPerTransaction: [1]
+    )
 
-    scenario 'two request-response pairs',
+    scenario('two request-response pairs',
       actionContent: '''
         + Request (application/json)
         + Response 200
@@ -100,8 +116,9 @@ describe 'detectTransactionExamples()', ->
         + Response 200
       '''
       exampleNumbersPerTransaction: [1, 2]
+    )
 
-    scenario 'three request-response pairs',
+    scenario('three request-response pairs',
       actionContent: '''
         + Request (application/json)
         + Response 200
@@ -113,24 +130,27 @@ describe 'detectTransactionExamples()', ->
         + Response 200
       '''
       exampleNumbersPerTransaction: [1, 2, 3]
+    )
 
-    scenario 'multiple requests with no response',
+    scenario('multiple requests with no response',
       actionContent: '''
         + Request (application/json)
         + Request (application/json)
         + Request (application/json)
       '''
       exampleNumbersPerTransaction: [1, 1, 1]
+    )
 
-    scenario 'no request with multiple responses',
+    scenario('no request with multiple responses',
       actionContent: '''
         + Response 200
         + Response 200
         + Response 200
       '''
       exampleNumbersPerTransaction: [1, 1, 1]
+    )
 
-    scenario 'no request with multiple responses followed by another example',
+    scenario('no request with multiple responses followed by another example',
       actionContent: '''
         + Response 200
         + Response 200
@@ -140,8 +160,9 @@ describe 'detectTransactionExamples()', ->
         + Response 200
       '''
       exampleNumbersPerTransaction: [1, 1, 1, 2]
+    )
 
-    scenario 'multiple requests with single response',
+    scenario('multiple requests with single response',
       actionContent: '''
         + Request (application/json)
         + Request (application/json)
@@ -149,8 +170,9 @@ describe 'detectTransactionExamples()', ->
         + Response 200
       '''
       exampleNumbersPerTransaction: [1, 1, 1]
+    )
 
-    scenario 'multiple requests with single response followed by another example',
+    scenario('multiple requests with single response followed by another example',
       actionContent: '''
         + Request (application/json)
         + Request (application/json)
@@ -161,8 +183,9 @@ describe 'detectTransactionExamples()', ->
         + Response 200
       '''
       exampleNumbersPerTransaction: [1, 1, 1, 2]
+    )
 
-    scenario 'single request with multiple responses',
+    scenario('single request with multiple responses',
       actionContent: '''
         + Request (application/json)
         + Response 200
@@ -170,8 +193,9 @@ describe 'detectTransactionExamples()', ->
         + Response 200
       '''
       exampleNumbersPerTransaction: [1, 1, 1]
+    )
 
-    scenario 'single request with multiple responses followed by another example',
+    scenario('single request with multiple responses followed by another example',
       actionContent: '''
         + Request (application/json)
         + Response 200
@@ -182,8 +206,9 @@ describe 'detectTransactionExamples()', ->
         + Response 200
       '''
       exampleNumbersPerTransaction: [1, 1, 1, 2]
+    )
 
-    scenario 'multiple requests with multiple responses',
+    scenario('multiple requests with multiple responses',
       actionContent: '''
         + Request (application/json)
         + Request (application/json)
@@ -193,8 +218,9 @@ describe 'detectTransactionExamples()', ->
         + Response 200
       '''
       exampleNumbersPerTransaction: [1, 1, 1, 1, 1, 1, 1, 1, 1]
+    )
 
-    scenario 'multiple requests with multiple responses followed by another example',
+    scenario('multiple requests with multiple responses followed by another example',
       actionContent: '''
         + Request (application/json)
         + Request (application/json)
@@ -207,8 +233,9 @@ describe 'detectTransactionExamples()', ->
         + Response 200
       '''
       exampleNumbersPerTransaction: [1, 1, 1, 1, 1, 1, 1, 1, 1, 2]
+    )
 
-    scenario 'multiple requests with multiple responses followed by another multiple requests with multiple responses',
+    scenario('multiple requests with multiple responses followed by another multiple requests with multiple responses',
       actionContent: '''
         + Request (application/json)
         + Request (application/json)
@@ -223,10 +250,12 @@ describe 'detectTransactionExamples()', ->
         + Response 200
       '''
       exampleNumbersPerTransaction: [1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2]
+    )
+  )
 
 
-  describe 'various ways of specifying requests', ->
-    scenario 'bare',
+  describe('various ways of specifying requests', ->
+    scenario('bare',
       skip: true # https://github.com/apiaryio/drafter/issues/259
       actionContent: '''
         + Request
@@ -240,8 +269,9 @@ describe 'detectTransactionExamples()', ->
         + Response 200
       '''
       exampleNumbersPerTransaction: [1, 2, 2, 3]
+    )
 
-    scenario 'with Content-Type headers',
+    scenario('with Content-Type headers',
       actionContent: '''
         + Request (application/json)
         + Response 200
@@ -254,8 +284,9 @@ describe 'detectTransactionExamples()', ->
         + Response 200
       '''
       exampleNumbersPerTransaction: [1, 2, 2, 3]
+    )
 
-    scenario 'with Headers section',
+    scenario('with Headers section',
       actionContent: '''
         + Request
             + Headers
@@ -276,8 +307,9 @@ describe 'detectTransactionExamples()', ->
         + Response 200
       '''
       exampleNumbersPerTransaction: [1, 2, 2, 3]
+    )
 
-    scenario 'with bare Headers section',
+    scenario('with bare Headers section',
       skip: true # https://github.com/apiaryio/drafter/issues/259
       actionContent: '''
         + Request
@@ -295,8 +327,9 @@ describe 'detectTransactionExamples()', ->
         + Response 200
       '''
       exampleNumbersPerTransaction: [1, 2, 2, 3]
+    )
 
-    scenario 'with Attributes section',
+    scenario('with Attributes section',
       actionContent: '''
         + Request
             + Attributes
@@ -317,8 +350,9 @@ describe 'detectTransactionExamples()', ->
         + Response 200
       '''
       exampleNumbersPerTransaction: [1, 2, 2, 3]
+    )
 
-    scenario 'with bare Attributes section',
+    scenario('with bare Attributes section',
       skip: true # https://github.com/apiaryio/drafter/issues/259
       actionContent: '''
         + Request
@@ -336,8 +370,9 @@ describe 'detectTransactionExamples()', ->
         + Response 200
       '''
       exampleNumbersPerTransaction: [1, 2, 2, 3]
+    )
 
-    scenario 'with Body section',
+    scenario('with Body section',
       actionContent: '''
         + Request
             + Body
@@ -358,8 +393,9 @@ describe 'detectTransactionExamples()', ->
         + Response 200
       '''
       exampleNumbersPerTransaction: [1, 2, 2, 3]
+    )
 
-    scenario 'with bare Body section',
+    scenario('with bare Body section',
       skip: true # https://github.com/apiaryio/drafter/issues/259
       actionContent: '''
         + Request
@@ -377,8 +413,9 @@ describe 'detectTransactionExamples()', ->
         + Response 200
       '''
       exampleNumbersPerTransaction: [1, 2, 2, 3]
+    )
 
-    scenario 'with Schema section',
+    scenario('with Schema section',
       actionContent: '''
         + Request
             + Schema
@@ -399,8 +436,9 @@ describe 'detectTransactionExamples()', ->
         + Response 200
       '''
       exampleNumbersPerTransaction: [1, 2, 2, 3]
+    )
 
-    scenario 'with bare Schema section',
+    scenario('with bare Schema section',
       skip: true # https://github.com/apiaryio/drafter/issues/259
       actionContent: '''
         + Request
@@ -418,10 +456,12 @@ describe 'detectTransactionExamples()', ->
         + Response 200
       '''
       exampleNumbersPerTransaction: [1, 2, 2, 3]
+    )
+  )
 
 
-  describe 'various ways of specifying responses', ->
-    scenario 'bare',
+  describe('various ways of specifying responses', ->
+    scenario('bare',
       skip: true # https://github.com/apiaryio/drafter/issues/259
       actionContent: '''
         + Request (application/json)
@@ -435,196 +475,209 @@ describe 'detectTransactionExamples()', ->
         + Response
       '''
       exampleNumbersPerTransaction: [1, 2, 2, 3]
+    )
 
-  scenario 'with satus codes',
-    actionContent: '''
-      + Request (application/json)
-      + Response 200
+    scenario('with satus codes',
+      actionContent: '''
+        + Request (application/json)
+        + Response 200
 
-      + Request (application/json)
-      + Response 200
-      + Response 200
+        + Request (application/json)
+        + Response 200
+        + Response 200
 
-      + Request (application/json)
-      + Response 200
-    '''
-    exampleNumbersPerTransaction: [1, 2, 2, 3]
+        + Request (application/json)
+        + Response 200
+      '''
+      exampleNumbersPerTransaction: [1, 2, 2, 3]
+    )
 
-  scenario 'with Content-Type headers',
-    actionContent: '''
-      + Request (application/json)
-      + Response (application/json)
+    scenario('with Content-Type headers',
+      actionContent: '''
+        + Request (application/json)
+        + Response (application/json)
 
-      + Request (application/json)
-      + Response (application/json)
-      + Response (application/json)
+        + Request (application/json)
+        + Response (application/json)
+        + Response (application/json)
 
-      + Request (application/json)
-      + Response (application/json)
-    '''
-    exampleNumbersPerTransaction: [1, 2, 2, 3]
+        + Request (application/json)
+        + Response (application/json)
+      '''
+      exampleNumbersPerTransaction: [1, 2, 2, 3]
+    )
 
-  scenario 'with Headers section',
-    actionContent: '''
-      + Request (application/json)
-      + Response
-          + Headers
-              X-Smurf: Brainy Smurf
+    scenario('with Headers section',
+      actionContent: '''
+        + Request (application/json)
+        + Response
+            + Headers
+                X-Smurf: Brainy Smurf
 
-      + Request (application/json)
-      + Response
-          + Headers
-              X-Smurf: Grouchy Smurf
-      + Response
-          + Headers
-              X-Smurf: Clumsy Smurf
+        + Request (application/json)
+        + Response
+            + Headers
+                X-Smurf: Grouchy Smurf
+        + Response
+            + Headers
+                X-Smurf: Clumsy Smurf
 
-      + Request (application/json)
-      + Response
-          + Headers
-              X-Smurf: Greedy Smurf
-    '''
-    exampleNumbersPerTransaction: [1, 2, 2, 3]
+        + Request (application/json)
+        + Response
+            + Headers
+                X-Smurf: Greedy Smurf
+      '''
+      exampleNumbersPerTransaction: [1, 2, 2, 3]
+    )
 
-  scenario 'with bare Headers section',
-    skip: true # https://github.com/apiaryio/drafter/issues/259
-    actionContent: '''
-      + Request (application/json)
-      + Response
-          + Headers
+    scenario('with bare Headers section',
+      skip: true # https://github.com/apiaryio/drafter/issues/259
+      actionContent: '''
+        + Request (application/json)
+        + Response
+            + Headers
 
-      + Request (application/json)
-      + Response
-          + Headers
-      + Response
-          + Headers
+        + Request (application/json)
+        + Response
+            + Headers
+        + Response
+            + Headers
 
-      + Request (application/json)
-      + Response
-          + Headers
-    '''
-    exampleNumbersPerTransaction: [1, 2, 2, 3]
+        + Request (application/json)
+        + Response
+            + Headers
+      '''
+      exampleNumbersPerTransaction: [1, 2, 2, 3]
+    )
 
-  scenario 'with Attributes section',
-    actionContent: '''
-      + Request (application/json)
-      + Response
-          + Attributes
-              + smurfColor: blue
+    scenario('with Attributes section',
+      actionContent: '''
+        + Request (application/json)
+        + Response
+            + Attributes
+                + smurfColor: blue
 
-      + Request (application/json)
-      + Response
-          + Attributes
-              + smurfColor: blue
-      + Response
-          + Attributes
-              + smurfColor: blue
+        + Request (application/json)
+        + Response
+            + Attributes
+                + smurfColor: blue
+        + Response
+            + Attributes
+                + smurfColor: blue
 
-      + Request (application/json)
-      + Response
-          + Attributes
-              + smurfColor: blue
-    '''
-    exampleNumbersPerTransaction: [1, 2, 2, 3]
+        + Request (application/json)
+        + Response
+            + Attributes
+                + smurfColor: blue
+      '''
+      exampleNumbersPerTransaction: [1, 2, 2, 3]
+    )
 
-  scenario 'with bare Attributes section',
-    skip: true # https://github.com/apiaryio/drafter/issues/259
-    actionContent: '''
-      + Request (application/json)
-      + Response
-          + Attributes
+    scenario('with bare Attributes section',
+      skip: true # https://github.com/apiaryio/drafter/issues/259
+      actionContent: '''
+        + Request (application/json)
+        + Response
+            + Attributes
 
-      + Request (application/json)
-      + Response
-          + Attributes
-      + Response
-          + Attributes
+        + Request (application/json)
+        + Response
+            + Attributes
+        + Response
+            + Attributes
 
-      + Request (application/json)
-      + Response
-          + Attributes
-    '''
-    exampleNumbersPerTransaction: [1, 2, 2, 3]
+        + Request (application/json)
+        + Response
+            + Attributes
+      '''
+      exampleNumbersPerTransaction: [1, 2, 2, 3]
+    )
 
-  scenario 'with Body section',
-    actionContent: '''
-      + Request (application/json)
-      + Response
-          + Body
-              {}
+    scenario('with Body section',
+      actionContent: '''
+        + Request (application/json)
+        + Response
+            + Body
+                {}
 
-      + Request (application/json)
-      + Response
-          + Body
-              {}
-      + Response
-          + Body
-              {}
+        + Request (application/json)
+        + Response
+            + Body
+                {}
+        + Response
+            + Body
+                {}
 
-      + Request (application/json)
-      + Response
-          + Body
-              {}
-    '''
-    exampleNumbersPerTransaction: [1, 2, 2, 3]
+        + Request (application/json)
+        + Response
+            + Body
+                {}
+      '''
+      exampleNumbersPerTransaction: [1, 2, 2, 3]
+    )
 
-  scenario 'with bare Body section',
-    skip: true # https://github.com/apiaryio/drafter/issues/259
-    actionContent: '''
-      + Request (application/json)
-      + Response
-          + Body
+    scenario('with bare Body section',
+      skip: true # https://github.com/apiaryio/drafter/issues/259
+      actionContent: '''
+        + Request (application/json)
+        + Response
+            + Body
 
-      + Request (application/json)
-      + Response
-          + Body
-      + Response
-          + Body
+        + Request (application/json)
+        + Response
+            + Body
+        + Response
+            + Body
 
-      + Request (application/json)
-      + Response
-          + Body
-    '''
-    exampleNumbersPerTransaction: [1, 2, 2, 3]
+        + Request (application/json)
+        + Response
+            + Body
+      '''
+      exampleNumbersPerTransaction: [1, 2, 2, 3]
+    )
 
-  scenario 'with Schema section',
-    actionContent: '''
-      + Request (application/json)
-      + Response
-          + Schema
-              {}
+    scenario('with Schema section',
+      actionContent: '''
+        + Request (application/json)
+        + Response
+            + Schema
+                {}
 
-      + Request (application/json)
-      + Response
-          + Schema
-              {}
-      + Response
-          + Schema
-              {}
+        + Request (application/json)
+        + Response
+            + Schema
+                {}
+        + Response
+            + Schema
+                {}
 
-      + Request (application/json)
-      + Response
-          + Schema
-              {}
-    '''
-    exampleNumbersPerTransaction: [1, 2, 2, 3]
+        + Request (application/json)
+        + Response
+            + Schema
+                {}
+      '''
+      exampleNumbersPerTransaction: [1, 2, 2, 3]
+    )
 
-  scenario 'with bare Schema section',
-    skip: true # https://github.com/apiaryio/drafter/issues/259
-    actionContent: '''
-      + Request (application/json)
-      + Response
-          + Schema
+    scenario('with bare Schema section',
+      skip: true # https://github.com/apiaryio/drafter/issues/259
+      actionContent: '''
+        + Request (application/json)
+        + Response
+            + Schema
 
-      + Request (application/json)
-      + Response
-          + Schema
-      + Response
-          + Schema
-              {}
+        + Request (application/json)
+        + Response
+            + Schema
+        + Response
+            + Schema
+                {}
 
-      + Request (application/json)
-      + Response
-          + Schema
-    '''
-    exampleNumbersPerTransaction: [1, 2, 2, 3]
+        + Request (application/json)
+        + Response
+            + Schema
+      '''
+      exampleNumbersPerTransaction: [1, 2, 2, 3]
+    )
+  )
+)

--- a/test/unit/detect-transaction-examples-test.coffee
+++ b/test/unit/detect-transaction-examples-test.coffee
@@ -6,9 +6,7 @@ detectTransactionExamples = require('../../src/detect-transaction-examples')
 
 
 # Encapsulates a single test scenario.
-scenario = (description, {actionContent, examples, exampleNumbersPerTransaction, skip}) ->
-  return if skip
-
+scenario = (description, {actionContent, examples, exampleNumbersPerTransaction}) ->
   describe("#{description}", ->
     apiBlueprint = """
       FORMAT: 1A
@@ -256,7 +254,6 @@ describe('detectTransactionExamples()', ->
 
   describe('various ways of specifying requests', ->
     scenario('bare',
-      skip: true # https://github.com/apiaryio/drafter/issues/259
       actionContent: '''
         + Request
         + Response 200
@@ -310,7 +307,6 @@ describe('detectTransactionExamples()', ->
     )
 
     scenario('with bare Headers section',
-      skip: true # https://github.com/apiaryio/drafter/issues/259
       actionContent: '''
         + Request
             + Headers
@@ -353,7 +349,6 @@ describe('detectTransactionExamples()', ->
     )
 
     scenario('with bare Attributes section',
-      skip: true # https://github.com/apiaryio/drafter/issues/259
       actionContent: '''
         + Request
             + Attributes
@@ -396,7 +391,6 @@ describe('detectTransactionExamples()', ->
     )
 
     scenario('with bare Body section',
-      skip: true # https://github.com/apiaryio/drafter/issues/259
       actionContent: '''
         + Request
             + Body
@@ -439,7 +433,6 @@ describe('detectTransactionExamples()', ->
     )
 
     scenario('with bare Schema section',
-      skip: true # https://github.com/apiaryio/drafter/issues/259
       actionContent: '''
         + Request
             + Schema
@@ -462,7 +455,6 @@ describe('detectTransactionExamples()', ->
 
   describe('various ways of specifying responses', ->
     scenario('bare',
-      skip: true # https://github.com/apiaryio/drafter/issues/259
       actionContent: '''
         + Request (application/json)
         + Response
@@ -531,7 +523,6 @@ describe('detectTransactionExamples()', ->
     )
 
     scenario('with bare Headers section',
-      skip: true # https://github.com/apiaryio/drafter/issues/259
       actionContent: '''
         + Request (application/json)
         + Response
@@ -574,7 +565,6 @@ describe('detectTransactionExamples()', ->
     )
 
     scenario('with bare Attributes section',
-      skip: true # https://github.com/apiaryio/drafter/issues/259
       actionContent: '''
         + Request (application/json)
         + Response
@@ -617,7 +607,6 @@ describe('detectTransactionExamples()', ->
     )
 
     scenario('with bare Body section',
-      skip: true # https://github.com/apiaryio/drafter/issues/259
       actionContent: '''
         + Request (application/json)
         + Response
@@ -660,7 +649,6 @@ describe('detectTransactionExamples()', ->
     )
 
     scenario('with bare Schema section',
-      skip: true # https://github.com/apiaryio/drafter/issues/259
       actionContent: '''
         + Request (application/json)
         + Response

--- a/test/unit/detect-transaction-examples-test.coffee
+++ b/test/unit/detect-transaction-examples-test.coffee
@@ -1,0 +1,630 @@
+
+{assert} = require 'chai'
+protagonist = require 'protagonist'
+
+detectTransactionExamples = require '../../src/detect-transaction-examples'
+
+
+# Encapsulates a single test scenario.
+scenario = (description, {actionContent, examples, exampleNumbersPerTransaction, skip}) ->
+  return if skip
+
+  describe "#{description}", ->
+    apiBlueprint = """
+      FORMAT: 1A
+      # Gargamel API
+      # Group Smurfs
+      ## Smurfs [/smurfs]
+      ### Catch a Smurf [POST]
+      #{actionContent}
+    """
+    action = undefined # API Blueprint AST
+    transition = undefined # API Elements (a.k.a. Refract)
+
+    beforeEach (done) ->
+      options = {type: 'ast', generateSourceMap: true}
+      protagonist.parse apiBlueprint, options, (err, parseResult) ->
+        return done err if err
+        action = parseResult.ast.resourceGroups[0].resources[0].actions[0]
+        done()
+
+    beforeEach (done) ->
+      options = {type: 'refract', generateSourceMap: true}
+      protagonist.parse apiBlueprint, options, (err, parseResult) ->
+        return done err if err
+        transition = parseResult.content[0].content[0].content[0].content[0]
+        done()
+
+    beforeEach ->
+      detectTransactionExamples transition
+
+    it 'transactions got expected example numbers', ->
+      expected = []
+      for example, exampleIndex in action.examples
+        for requestIndex in [0...(example.requests.length or 1)]
+          for responseIndex in [0...(example.responses.length or 1)]
+            expected.push exampleIndex + 1
+
+      assert.deepEqual expected, (trans.attributes?.example for trans in transition.content)
+
+
+describe 'detectTransactionExamples()', ->
+  describe 'various combinations of requests and responses', ->
+    scenario 'empty action',
+      actionContent: ''
+      exampleNumbersPerTransaction: []
+
+    scenario 'single request',
+      actionContent: '''
+        + Request (application/json)
+      '''
+      exampleNumbersPerTransaction: [1]
+
+    scenario 'single response',
+      actionContent: '''
+        + Response 200
+      '''
+      exampleNumbersPerTransaction: [1]
+
+    scenario 'single response followed by another example',
+      actionContent: '''
+        + Response 200
+
+        + Request (application/json)
+        + Response 200
+      '''
+      exampleNumbersPerTransaction: [1, 2]
+
+    scenario 'single response followed by a single request-response pair',
+      actionContent: '''
+        + Response 200
+
+        + Request (application/json)
+        + Response 200
+      '''
+      exampleNumbersPerTransaction: [1, 2]
+
+    scenario 'single request-response pair',
+      actionContent: '''
+        + Request (application/json)
+        + Response 200
+      '''
+      exampleNumbersPerTransaction: [1]
+
+    scenario 'two request-response pairs',
+      actionContent: '''
+        + Request (application/json)
+        + Response 200
+
+        + Request (application/json)
+        + Response 200
+      '''
+      exampleNumbersPerTransaction: [1, 2]
+
+    scenario 'three request-response pairs',
+      actionContent: '''
+        + Request (application/json)
+        + Response 200
+
+        + Request (application/json)
+        + Response 200
+
+        + Request (application/json)
+        + Response 200
+      '''
+      exampleNumbersPerTransaction: [1, 2, 3]
+
+    scenario 'multiple requests with no response',
+      actionContent: '''
+        + Request (application/json)
+        + Request (application/json)
+        + Request (application/json)
+      '''
+      exampleNumbersPerTransaction: [1, 1, 1]
+
+    scenario 'no request with multiple responses',
+      actionContent: '''
+        + Response 200
+        + Response 200
+        + Response 200
+      '''
+      exampleNumbersPerTransaction: [1, 1, 1]
+
+    scenario 'no request with multiple responses followed by another example',
+      actionContent: '''
+        + Response 200
+        + Response 200
+        + Response 200
+
+        + Request (application/json)
+        + Response 200
+      '''
+      exampleNumbersPerTransaction: [1, 1, 1, 2]
+
+    scenario 'multiple requests with single response',
+      actionContent: '''
+        + Request (application/json)
+        + Request (application/json)
+        + Request (application/json)
+        + Response 200
+      '''
+      exampleNumbersPerTransaction: [1, 1, 1]
+
+    scenario 'multiple requests with single response followed by another example',
+      actionContent: '''
+        + Request (application/json)
+        + Request (application/json)
+        + Request (application/json)
+        + Response 200
+
+        + Request (application/json)
+        + Response 200
+      '''
+      exampleNumbersPerTransaction: [1, 1, 1, 2]
+
+    scenario 'single request with multiple responses',
+      actionContent: '''
+        + Request (application/json)
+        + Response 200
+        + Response 200
+        + Response 200
+      '''
+      exampleNumbersPerTransaction: [1, 1, 1]
+
+    scenario 'single request with multiple responses followed by another example',
+      actionContent: '''
+        + Request (application/json)
+        + Response 200
+        + Response 200
+        + Response 200
+
+        + Request (application/json)
+        + Response 200
+      '''
+      exampleNumbersPerTransaction: [1, 1, 1, 2]
+
+    scenario 'multiple requests with multiple responses',
+      actionContent: '''
+        + Request (application/json)
+        + Request (application/json)
+        + Request (application/json)
+        + Response 200
+        + Response 200
+        + Response 200
+      '''
+      exampleNumbersPerTransaction: [1, 1, 1, 1, 1, 1, 1, 1, 1]
+
+    scenario 'multiple requests with multiple responses followed by another example',
+      actionContent: '''
+        + Request (application/json)
+        + Request (application/json)
+        + Request (application/json)
+        + Response 200
+        + Response 200
+        + Response 200
+
+        + Request (application/json)
+        + Response 200
+      '''
+      exampleNumbersPerTransaction: [1, 1, 1, 1, 1, 1, 1, 1, 1, 2]
+
+    scenario 'multiple requests with multiple responses followed by another multiple requests with multiple responses',
+      actionContent: '''
+        + Request (application/json)
+        + Request (application/json)
+        + Request (application/json)
+        + Response 200
+        + Response 200
+        + Response 200
+
+        + Request (application/json)
+        + Request (application/json)
+        + Response 200
+        + Response 200
+      '''
+      exampleNumbersPerTransaction: [1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2]
+
+
+  describe 'various ways of specifying requests', ->
+    scenario 'bare',
+      skip: true # https://github.com/apiaryio/drafter/issues/259
+      actionContent: '''
+        + Request
+        + Response 200
+
+        + Request
+        + Request
+        + Response 200
+
+        + Request
+        + Response 200
+      '''
+      exampleNumbersPerTransaction: [1, 2, 2, 3]
+
+    scenario 'with Content-Type headers',
+      actionContent: '''
+        + Request (application/json)
+        + Response 200
+
+        + Request (application/json)
+        + Request (application/json)
+        + Response 200
+
+        + Request (application/json)
+        + Response 200
+      '''
+      exampleNumbersPerTransaction: [1, 2, 2, 3]
+
+    scenario 'with Headers section',
+      actionContent: '''
+        + Request
+            + Headers
+                X-Smurf: Papa Smurf
+        + Response 200
+
+        + Request
+            + Headers
+                X-Smurf: Smurfette
+        + Request
+            + Headers
+                X-Smurf: Hefty Smurf
+        + Response 200
+
+        + Request
+            + Headers
+                X-Smurf: Brainy Smurf
+        + Response 200
+      '''
+      exampleNumbersPerTransaction: [1, 2, 2, 3]
+
+    scenario 'with bare Headers section',
+      skip: true # https://github.com/apiaryio/drafter/issues/259
+      actionContent: '''
+        + Request
+            + Headers
+        + Response 200
+
+        + Request
+            + Headers
+        + Request
+            + Headers
+        + Response 200
+
+        + Request
+            + Headers
+        + Response 200
+      '''
+      exampleNumbersPerTransaction: [1, 2, 2, 3]
+
+    scenario 'with Attributes section',
+      actionContent: '''
+        + Request
+            + Attributes
+                + smurfColor: blue
+        + Response 200
+
+        + Request
+            + Attributes
+                + smurfColor: blue
+        + Request
+            + Attributes
+                + smurfColor: blue
+        + Response 200
+
+        + Request
+            + Attributes
+                + smurfColor: blue
+        + Response 200
+      '''
+      exampleNumbersPerTransaction: [1, 2, 2, 3]
+
+    scenario 'with bare Attributes section',
+      skip: true # https://github.com/apiaryio/drafter/issues/259
+      actionContent: '''
+        + Request
+            + Attributes
+        + Response 200
+
+        + Request
+            + Attributes
+        + Request
+            + Attributes
+        + Response 200
+
+        + Request
+            + Attributes
+        + Response 200
+      '''
+      exampleNumbersPerTransaction: [1, 2, 2, 3]
+
+    scenario 'with Body section',
+      actionContent: '''
+        + Request
+            + Body
+                {}
+        + Response 200
+
+        + Request
+            + Body
+                {}
+        + Request
+            + Body
+                {}
+        + Response 200
+
+        + Request
+            + Body
+                {}
+        + Response 200
+      '''
+      exampleNumbersPerTransaction: [1, 2, 2, 3]
+
+    scenario 'with bare Body section',
+      skip: true # https://github.com/apiaryio/drafter/issues/259
+      actionContent: '''
+        + Request
+            + Body
+        + Response 200
+
+        + Request
+            + Body
+        + Request
+            + Body
+        + Response 200
+
+        + Request
+            + Body
+        + Response 200
+      '''
+      exampleNumbersPerTransaction: [1, 2, 2, 3]
+
+    scenario 'with Schema section',
+      actionContent: '''
+        + Request
+            + Schema
+                {}
+        + Response 200
+
+        + Request
+            + Schema
+                {}
+        + Request
+            + Schema
+                {}
+        + Response 200
+
+        + Request
+            + Schema
+                {}
+        + Response 200
+      '''
+      exampleNumbersPerTransaction: [1, 2, 2, 3]
+
+    scenario 'with bare Schema section',
+      skip: true # https://github.com/apiaryio/drafter/issues/259
+      actionContent: '''
+        + Request
+            + Schema
+        + Response 200
+
+        + Request
+            + Schema
+        + Request
+            + Schema
+        + Response 200
+
+        + Request
+            + Schema
+        + Response 200
+      '''
+      exampleNumbersPerTransaction: [1, 2, 2, 3]
+
+
+  describe 'various ways of specifying responses', ->
+    scenario 'bare',
+      skip: true # https://github.com/apiaryio/drafter/issues/259
+      actionContent: '''
+        + Request (application/json)
+        + Response
+
+        + Request (application/json)
+        + Response
+        + Response
+
+        + Request (application/json)
+        + Response
+      '''
+      exampleNumbersPerTransaction: [1, 2, 2, 3]
+
+  scenario 'with satus codes',
+    actionContent: '''
+      + Request (application/json)
+      + Response 200
+
+      + Request (application/json)
+      + Response 200
+      + Response 200
+
+      + Request (application/json)
+      + Response 200
+    '''
+    exampleNumbersPerTransaction: [1, 2, 2, 3]
+
+  scenario 'with Content-Type headers',
+    actionContent: '''
+      + Request (application/json)
+      + Response (application/json)
+
+      + Request (application/json)
+      + Response (application/json)
+      + Response (application/json)
+
+      + Request (application/json)
+      + Response (application/json)
+    '''
+    exampleNumbersPerTransaction: [1, 2, 2, 3]
+
+  scenario 'with Headers section',
+    actionContent: '''
+      + Request (application/json)
+      + Response
+          + Headers
+              X-Smurf: Brainy Smurf
+
+      + Request (application/json)
+      + Response
+          + Headers
+              X-Smurf: Grouchy Smurf
+      + Response
+          + Headers
+              X-Smurf: Clumsy Smurf
+
+      + Request (application/json)
+      + Response
+          + Headers
+              X-Smurf: Greedy Smurf
+    '''
+    exampleNumbersPerTransaction: [1, 2, 2, 3]
+
+  scenario 'with bare Headers section',
+    skip: true # https://github.com/apiaryio/drafter/issues/259
+    actionContent: '''
+      + Request (application/json)
+      + Response
+          + Headers
+
+      + Request (application/json)
+      + Response
+          + Headers
+      + Response
+          + Headers
+
+      + Request (application/json)
+      + Response
+          + Headers
+    '''
+    exampleNumbersPerTransaction: [1, 2, 2, 3]
+
+  scenario 'with Attributes section',
+    actionContent: '''
+      + Request (application/json)
+      + Response
+          + Attributes
+              + smurfColor: blue
+
+      + Request (application/json)
+      + Response
+          + Attributes
+              + smurfColor: blue
+      + Response
+          + Attributes
+              + smurfColor: blue
+
+      + Request (application/json)
+      + Response
+          + Attributes
+              + smurfColor: blue
+    '''
+    exampleNumbersPerTransaction: [1, 2, 2, 3]
+
+  scenario 'with bare Attributes section',
+    skip: true # https://github.com/apiaryio/drafter/issues/259
+    actionContent: '''
+      + Request (application/json)
+      + Response
+          + Attributes
+
+      + Request (application/json)
+      + Response
+          + Attributes
+      + Response
+          + Attributes
+
+      + Request (application/json)
+      + Response
+          + Attributes
+    '''
+    exampleNumbersPerTransaction: [1, 2, 2, 3]
+
+  scenario 'with Body section',
+    actionContent: '''
+      + Request (application/json)
+      + Response
+          + Body
+              {}
+
+      + Request (application/json)
+      + Response
+          + Body
+              {}
+      + Response
+          + Body
+              {}
+
+      + Request (application/json)
+      + Response
+          + Body
+              {}
+    '''
+    exampleNumbersPerTransaction: [1, 2, 2, 3]
+
+  scenario 'with bare Body section',
+    skip: true # https://github.com/apiaryio/drafter/issues/259
+    actionContent: '''
+      + Request (application/json)
+      + Response
+          + Body
+
+      + Request (application/json)
+      + Response
+          + Body
+      + Response
+          + Body
+
+      + Request (application/json)
+      + Response
+          + Body
+    '''
+    exampleNumbersPerTransaction: [1, 2, 2, 3]
+
+  scenario 'with Schema section',
+    actionContent: '''
+      + Request (application/json)
+      + Response
+          + Schema
+              {}
+
+      + Request (application/json)
+      + Response
+          + Schema
+              {}
+      + Response
+          + Schema
+              {}
+
+      + Request (application/json)
+      + Response
+          + Schema
+              {}
+    '''
+    exampleNumbersPerTransaction: [1, 2, 2, 3]
+
+  scenario 'with bare Schema section',
+    skip: true # https://github.com/apiaryio/drafter/issues/259
+    actionContent: '''
+      + Request (application/json)
+      + Response
+          + Schema
+
+      + Request (application/json)
+      + Response
+          + Schema
+      + Response
+          + Schema
+              {}
+
+      + Request (application/json)
+      + Response
+          + Schema
+    '''
+    exampleNumbersPerTransaction: [1, 2, 2, 3]


### PR DESCRIPTION
This Pull Request introduces function, which takes Transition Element node from API Elements tree and detects a HTTP Transaction Example number for each transaction.

This allows us to still support HTTP Transaction Examples after switching to API Elements, although they do not exist in API Elements.