### PR TITLE
Parsing of API description documents

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "dependencies": {
     "clone": "^1.0.2",
     "traverse": "^0.6.6",
-    "uri-template": "^1.0.0"
+    "uri-template": "^1.0.0",
+    "protagonist": "1.3.0-pre.1"
   },
   "devDependencies": {
     "chai": "^3.4.1",
@@ -30,7 +31,7 @@
     "jscoverage": "^0.6.0",
     "mocha": "^2.3.4",
     "mocha-lcov-reporter": "^1.0.0",
-    "protagonist": "^1.3.0-pre.1"
+    "sinon": "^1.17.3"
   },
   "keywords": [
     "api",

--- a/src/parse.coffee
+++ b/src/parse.coffee
@@ -1,0 +1,19 @@
+
+protagonist = require('protagonist')
+
+
+parse = (apiDescriptionDocument, done) ->
+  options = {generateSourceMap: true}
+  protagonist.parse(apiDescriptionDocument, options, (err, result) ->
+    if not (err or result)
+      err = new Error('Unexpected parser error occurred.')
+    else if err
+      # Turning Protagonist error object into standard JavaScript error
+      err = new Error(err.message)
+
+    # If no parse result is present, indicate that with 'null', not 'undefined'
+    done(err, result or null)
+  )
+
+
+module.exports = {parse}

--- a/src/parse.coffee
+++ b/src/parse.coffee
@@ -2,7 +2,7 @@
 protagonist = require('protagonist')
 
 
-parse = (apiDescriptionDocument, done) ->
+parse = (apiDescriptionDocument, callback) ->
   options = {generateSourceMap: true}
   protagonist.parse(apiDescriptionDocument, options, (err, result) ->
     if not (err or result)
@@ -12,7 +12,7 @@ parse = (apiDescriptionDocument, done) ->
       err = new Error(err.message)
 
     # If no parse result is present, indicate that with 'null', not 'undefined'
-    done(err, result or null)
+    callback(err, result or null)
   )
 
 

--- a/test/fixtures/parse-error.apib
+++ b/test/fixtures/parse-error.apib
@@ -1,0 +1,9 @@
+FORMAT: 1A
+
+# Sample API
+
+## GET /message
+
++ Response 200 (text/plain)
+
+	Hello World!

--- a/test/fixtures/parse-warning.apib
+++ b/test/fixtures/parse-warning.apib
@@ -1,0 +1,9 @@
+FORMAT: 1A
+
+# Sample API
+
+## GET /message
+
++ Response (text/plain)
+
+        Hello World!

--- a/test/fixtures/parse.apib
+++ b/test/fixtures/parse.apib
@@ -1,0 +1,9 @@
+FORMAT: 1A
+
+# Sample API
+
+## GET /message
+
++ Response 200 (text/plain)
+
+        Hello World!

--- a/test/unit/parse-test.coffee
+++ b/test/unit/parse-test.coffee
@@ -1,0 +1,129 @@
+
+fs = require('fs')
+path = require('path')
+
+sinon = require('sinon')
+protagonist = require('protagonist')
+{assert} = require('chai')
+{parse} = require('../../src/parse')
+
+
+describe('Parsing API description document', ->
+  fixturesDir = path.join(__dirname, '..', 'fixtures')
+
+  describe('Valid API Blueprint document gets correctly parsed', ->
+    fixture = path.join(fixturesDir, 'parse.apib')
+    apiDescriptionDocument = fs.readFileSync(fixture, 'utf-8')
+
+    error = undefined
+    parseResult = undefined
+
+    beforeEach((done) ->
+      parse(apiDescriptionDocument, (args...) ->
+        [error, parseResult] = args
+        done()
+      )
+    )
+
+    it('produces no error', ->
+      assert.isNull(error)
+    )
+    it('produces parse result', ->
+      assert.isObject(parseResult)
+    )
+    it('the parse result is in the API Elements format', ->
+      assert.equal(parseResult.element, 'parseResult')
+      assert.isArray(parseResult.content)
+    )
+    it('the parse result contains no annotation elements', ->
+      assert.notInclude(JSON.stringify(parseResult), '"annotation"')
+    )
+    it('the parse result contains source map elements', ->
+      assert.include(JSON.stringify(parseResult), '"sourceMap"')
+    )
+  )
+
+  describe('Invalid API Blueprint document causes error', ->
+    fixture = path.join(fixturesDir, 'parse-error.apib')
+    apiDescriptionDocument = fs.readFileSync(fixture, 'utf-8')
+
+    error = undefined
+    parseResult = undefined
+
+    beforeEach((done) ->
+      parse(apiDescriptionDocument, (args...) ->
+        [error, parseResult] = args
+        done()
+      )
+    )
+
+    it('produces error', ->
+      assert.instanceOf(error, Error)
+    )
+    it('produces parse result', ->
+      assert.isObject(parseResult)
+    )
+    it('the parse result contains annotation element', ->
+      assert.include(JSON.stringify(parseResult), '"annotation"')
+    )
+    it('the annotation is an error', ->
+      assert.include(JSON.stringify(parseResult), '"error"')
+    )
+  )
+
+  describe('Defective API Blueprint document causes warning', ->
+    fixture = path.join(fixturesDir, 'parse-warning.apib')
+    apiDescriptionDocument = fs.readFileSync(fixture, 'utf-8')
+
+    error = undefined
+    parseResult = undefined
+
+    beforeEach((done) ->
+      parse(apiDescriptionDocument, (args...) ->
+        [error, parseResult] = args
+        done()
+      )
+    )
+
+    it('produces no error', ->
+      assert.isNull(error)
+    )
+    it('produces parse result', ->
+      assert.isObject(parseResult)
+    )
+    it('the parse result contains annotation element', ->
+      assert.include(JSON.stringify(parseResult), '"annotation"')
+    )
+    it('the annotation is a warning', ->
+      assert.include(JSON.stringify(parseResult), '"warning"')
+    )
+  )
+
+  describe('Unexpected parser behavior causes \'unexpected parser error\'', ->
+    error = undefined
+    parseResult = undefined
+
+    beforeEach((done) ->
+      sinon.stub(protagonist, 'parse', (args...) ->
+        args.pop()() # calling the callback with neither error or parse result
+      )
+      parse('... dummy API description document ...', (args...) ->
+        [error, parseResult] = args
+        done()
+      )
+    )
+    afterEach( ->
+      protagonist.parse.restore()
+    )
+
+    it('produces error', ->
+      assert.instanceOf(error, Error)
+    )
+    it('the error is the \'unexpected parser error\' error', ->
+      assert.include(error.message.toLowerCase(), 'unexpected parser error')
+    )
+    it('produces no parse result', ->
+      assert.isNull(parseResult)
+    )
+  )
+)


### PR DESCRIPTION
Introducing parsing of API description document & tests.

Using pure Protagonist instead of Fury due to a bug - https://github.com/apiaryio/fury-adapter-apib-parser/issues/4#issuecomment-206214189. Fury won't be needed until https://github.com/apiaryio/dredd/issues/389 is going to be implemented, so we can go safely just with Protagonist now.
