### PR TITLE
Renaming 'type' of the annotation to 'component'

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Description of an error or warning which occurred during parsing of the API desc
 
 #### Properties
 
-- type (enum[string]) - Type of the annotation. Assigned according to in which part of compilation the error or warning occurred.
+- component (enum[string]) - In which component of the compilation process the annotation occurred.
     - `apiDescriptionParser`
     - `parametersValidation`
     - `uriTemplateExpansion`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dredd-transactions",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Compiles HTTP Transactions (Request-Response pairs) from API description document",
   "main": "lib/dredd-transactions.js",
   "scripts": {

--- a/src/from-api-elements/compile.coffee
+++ b/src/from-api-elements/compile.coffee
@@ -12,14 +12,11 @@ compileFromApiElements = (parseResult, filename) ->
   errors = []
   warnings = []
 
-  type = 'apiDescriptionParser'
+  component = 'apiDescriptionParser'
   for annotation in children(parseResult, {element: 'annotation'})
-    if annotation.meta.classes[0] is 'warning'
-      group = warnings
-    else
-      group = errors
+    group = if annotation.meta.classes[0] is 'warning' then warnings else errors
     group.push({
-      type
+      component
       code: content(annotation.attributes?.code)
       message: content(annotation)
       location: content(child(annotation.attributes?.sourceMap, {element: 'sourceMap'}))
@@ -103,18 +100,18 @@ compileUri = (parseResult, httpRequest) ->
       parameters[name] = parameter
 
   result = validateParameters(parameters)
-  type = 'parametersValidation'
+  component = 'parametersValidation'
   for error in result.errors
-    annotations.errors.push({type, message: error})
+    annotations.errors.push({component, message: error})
   for warning in result.warnings
-    annotations.warnings.push({type, message: warning})
+    annotations.warnings.push({component, message: warning})
 
   result = expandUriTemplateWithParameters(href, parameters)
-  type = 'uriTemplateExpansion'
+  component = 'uriTemplateExpansion'
   for error in result.errors
-    annotations.errors.push({type, message: error})
+    annotations.errors.push({component, message: error})
   for warning in result.warnings
-    annotations.warnings.push({type, message: warning})
+    annotations.warnings.push({component, message: warning})
 
   {uri: result.uri, annotations}
 

--- a/test/unit/from-api-elements/compile-test.coffee
+++ b/test/unit/from-api-elements/compile-test.coffee
@@ -41,7 +41,7 @@ describe('compileFromApiElements()', ->
     )
     context('the error', ->
       it('comes from parser', ->
-        assert.equal(errors[0].type, 'apiDescriptionParser')
+        assert.equal(errors[0].component, 'apiDescriptionParser')
       )
       it('has code', ->
         assert.ok(errors[0].code)
@@ -81,7 +81,7 @@ describe('compileFromApiElements()', ->
     )
     context('the error', ->
       it('comes from compiler', ->
-        assert.equal(errors[0].type, 'uriTemplateExpansion')
+        assert.equal(errors[0].component, 'uriTemplateExpansion')
       )
       it('has no code', ->
         assert.isUndefined(errors[0].code)
@@ -130,7 +130,7 @@ describe('compileFromApiElements()', ->
     )
     context('the error', ->
       it('comes from compiler', ->
-        assert.equal(errors[0].type, 'parametersValidation')
+        assert.equal(errors[0].component, 'parametersValidation')
       )
       it('has no code', ->
         assert.isUndefined(errors[0].code)
@@ -177,7 +177,7 @@ describe('compileFromApiElements()', ->
     )
     context('the warning', ->
       it('comes from parser', ->
-        assert.equal(warnings[0].type, 'apiDescriptionParser')
+        assert.equal(warnings[0].component, 'apiDescriptionParser')
       )
       it('has code', ->
         assert.ok(warnings[0].code)
@@ -217,7 +217,7 @@ describe('compileFromApiElements()', ->
     )
     context('the warning', ->
       it('comes from parser', ->
-        assert.equal(warnings[0].type, 'uriTemplateExpansion')
+        assert.equal(warnings[0].component, 'uriTemplateExpansion')
       )
       it('has no code', ->
         assert.isUndefined(warnings[0].code)
@@ -278,7 +278,7 @@ describe('compileFromApiElements()', ->
     )
     context('the warning', ->
       it('comes from compiler', ->
-        assert.equal(warnings[0].type, 'parametersValidation')
+        assert.equal(warnings[0].component, 'parametersValidation')
       )
       it('has no code', ->
         assert.isUndefined(warnings[0].code)


### PR DESCRIPTION
 Propagating type of the annotation. Original 'type' property renamed to 'component'.