### PR TITLE
Skip transactions with invalid URI template

### DIFF
--- a/src/expand-uri-template-with-parameters.coffee
+++ b/src/expand-uri-template-with-parameters.coffee
@@ -35,7 +35,7 @@ expandUriTemplateWithParameters = (uriTemplate, parameters) ->
       if Object.keys(parameters).indexOf(uriParameter) is -1
         ambiguous = true
         text = "\nAmbiguous URI parameter in template: #{uriTemplate} " + \
-               "\nParameter not defined in blueprint:" + \
+               "\nParameter not defined in API description: " + \
                "'" + uriParameter + "'"
         result['warnings'].push text
 
@@ -47,7 +47,7 @@ expandUriTemplateWithParameters = (uriTemplate, parameters) ->
           if param['example'] is undefined or param['example'] is ''
             ambiguous = true
             text = "\nAmbiguous URI parameter in template: #{uriTemplate} " + \
-                   "\nNo example value for required parameter in blueprint:" + \
+                   "\nNo example value for required parameter in API description: " + \
                    "'" + uriParameter + "'"
             result['warnings'].push text
           else

--- a/src/expand-uri-template-with-parameters.coffee
+++ b/src/expand-uri-template-with-parameters.coffee
@@ -28,7 +28,7 @@ expandUriTemplateWithParameters = (uriTemplate, parameters) ->
       if Object.keys(parameters).indexOf(uriParameter) is -1
         ambiguous = true
         text = "\nAmbiguous URI parameter in template: #{uriTemplate} " + \
-               "\nParameter not defined in API description: " + \
+               "\nParameter not defined in API description document: " + \
                "'" + uriParameter + "'"
         result['warnings'].push text
 
@@ -40,7 +40,7 @@ expandUriTemplateWithParameters = (uriTemplate, parameters) ->
           if param['example'] is undefined or param['example'] is ''
             ambiguous = true
             text = "\nAmbiguous URI parameter in template: #{uriTemplate} " + \
-                   "\nNo example value for required parameter in API description: " + \
+                   "\nNo example value for required parameter in API description document: " + \
                    "'" + uriParameter + "'"
             result['warnings'].push text
           else

--- a/src/expand-uri-template-with-parameters.coffee
+++ b/src/expand-uri-template-with-parameters.coffee
@@ -19,13 +19,6 @@ expandUriTemplateWithParameters = (uriTemplate, parameters) ->
     for param in expression['params']
       uriParameters.push param['name']
 
-  # check if all parameters from blueprint have an expression in URI
-  for parameter in Object.keys(parameters)
-    if uriParameters.indexOf(parameter) is -1
-      text = "\nURI template: #{uriTemplate}\nDoesn\'t contain expression for parameter" + \
-             " '" + parameter + "'"
-      result['warnings'].push text
-
   if parsed['expressions'].length is 0
     result['uri'] = uriTemplate
   else

--- a/src/from-api-elements/compile.coffee
+++ b/src/from-api-elements/compile.coffee
@@ -32,19 +32,20 @@ compileFromApiElements = (parseResult, filename) ->
     origin = compileOrigin(filename, parseResult, httpTransaction)
     {request, annotations} = compileRequest(parseResult, httpRequest)
 
+    if request
+      transactions.push({
+        origin
+        pathOrigin: compilePathOrigin(filename, parseResult, httpTransaction)
+        request
+        response: compileResponse(httpResponse)
+      })
+
     for error in annotations.errors
       error.origin = clone(origin)
       errors.push(error)
     for warning in annotations.warnings
       warning.origin = clone(origin)
       warnings.push(warning)
-
-    transactions.push({
-      origin
-      pathOrigin: compilePathOrigin(filename, parseResult, httpTransaction)
-      request
-      response: compileResponse(httpResponse)
-    })
 
   {transactions, errors, warnings}
 
@@ -53,16 +54,17 @@ compileRequest = (parseResult, httpRequest) ->
   messageBody = child(httpRequest, {element: 'asset', 'meta.classes': 'messageBody'})
 
   {uri, annotations} = compileUri(parseResult, httpRequest)
-
-  {
-    request: {
+  if uri
+    request = {
       method: content(httpRequest.attributes.method)
       uri
       headers: compileHeaders(child(httpRequest, {element: 'httpHeaders'}))
       body: content(messageBody) or ''
     }
-    annotations
-  }
+  else
+    request = null
+
+  {request, annotations}
 
 
 compileResponse = (httpResponse) ->

--- a/test/unit/expand-uri-template-with-parameters-test.coffee
+++ b/test/unit/expand-uri-template-with-parameters-test.coffee
@@ -81,20 +81,10 @@ describe 'expandUriTemplateWithParameters', ->
         it 'should return no error', ->
           assert.equal data['errors'].length, 0
 
-        it 'should return some warning', ->
-          assert.notEqual data['warnings'].length, 0
-
-        describe 'returned warning', ->
-          warning = ''
-          before ->
-            warning = data['warnings'][data['warnings'].length - 1]
-
-          it 'should contain paramter name', ->
-            assert.include warning, Object.keys(parameters)[0]
-
-          it 'sohuld contain proper text', ->
-            text = 'Doesn\'t contain expression for parameter'
-            assert.include warning, text
+        it 'should return no warning', ->
+          # The warning was removed as parser started to provide its own
+          # warning for the very same thing.
+          assert.equal data['warnings'].length, 0
 
         it 'should return URI as it is', ->
           assert.equal data['uri'], uriTemplate
@@ -148,8 +138,10 @@ describe 'expandUriTemplateWithParameters', ->
         it 'should return no error', ->
           assert.equal data['errors'].length, 0
 
-        it 'should return some warning', ->
-          assert.equal data['warnings'].length, 1
+        it 'should return no warning', ->
+          # The warning was removed as parser started to provide its own
+          # warning for the very same thing.
+          assert.equal data['warnings'].length, 0
 
         it 'should return expandend URI', ->
           assert.equal data['uri'], '/machines/waldo'
@@ -333,4 +325,3 @@ describe 'expandUriTemplateWithParameters', ->
 
           it 'should return some URI', ->
             assert.isNotNull data['uri']
-

--- a/test/unit/from-api-elements/compile-test.coffee
+++ b/test/unit/from-api-elements/compile-test.coffee
@@ -32,7 +32,7 @@ describe('compileFromApiElements()', ->
         \t\t
       ''', (args...) ->
         [err, {errors, transactions}] = args
-        done()
+        done() # not passing 'err' - we couldn't test 'errors'
       )
     )
 
@@ -75,7 +75,7 @@ describe('compileFromApiElements()', ->
         + Response
       ''', (args...) ->
         [err, {errors, transactions}] = args
-        done()
+        done() # not passing 'err' - we couldn't test 'errors'
       )
     )
 
@@ -127,7 +127,7 @@ describe('compileFromApiElements()', ->
         + Response
       ''', (args...) ->
         [err, {errors, transactions}] = args
-        done()
+        done() # not passing 'err' - we couldn't test 'errors'
       )
     )
 
@@ -177,7 +177,7 @@ describe('compileFromApiElements()', ->
         + Response
       ''', (args...) ->
         [err, {warnings, transactions}] = args
-        done()
+        done(err)
       )
     )
 
@@ -206,6 +206,45 @@ describe('compileFromApiElements()', ->
     )
   )
 
+  describe('API description causing a \'missing title\' warning', ->
+    err = undefined
+    warnings = undefined
+    transactions = undefined
+
+    beforeEach((done) ->
+      compile('''
+        So Long, and Thanks for All the Fish!
+      ''', (args...) ->
+        [err, {warnings, transactions}] = args
+        done(err)
+      )
+    )
+
+    it('is compiled into zero transactions', ->
+      assert.equal(transactions.length, 0)
+    )
+    it('is compiled with a warning', ->
+      assert.equal(warnings.length, 1)
+    )
+    context('the warning', ->
+      it('comes from parser', ->
+        assert.equal(warnings[0].component, 'apiDescriptionParser')
+      )
+      it('has code', ->
+        assert.isNumber(warnings[0].code)
+      )
+      it('has message', ->
+        assert.include(warnings[0].message.toLowerCase(), 'expected api name')
+      )
+      it('has expected location', ->
+        assert.deepEqual(warnings[0].location, [[0, 37]])
+      )
+      it('has no origin', ->
+        assert.isUndefined(warnings[0].origin)
+      )
+    )
+  )
+
   describe('API description causing a \'not specified in URI Template\' warning', ->
     # The warning was previously handled by compiler, but now parser already
     # provides the same kind of warning.
@@ -225,7 +264,7 @@ describe('compileFromApiElements()', ->
         + Response 203
       ''', (args...) ->
         [err, {warnings, transactions}] = args
-        done()
+        done(err)
       )
     )
 
@@ -340,7 +379,7 @@ describe('compileFromApiElements()', ->
         + Response 203
       ''', (args...) ->
         [err, {warnings, transactions}] = args
-        done()
+        done(err)
       )
     )
 

--- a/test/unit/from-api-elements/compile-test.coffee
+++ b/test/unit/from-api-elements/compile-test.coffee
@@ -14,7 +14,7 @@ compile = (apiDescriptionDocument, filename, done) ->
 
   options = {type: 'refract', generateSourceMap: true}
   protagonist.parse(apiDescriptionDocument, options, (err, parseResult) ->
-    return done(err) unless parseResult
+    return done(err or new Error('Unexpected error')) unless parseResult
     done(null, compileFromApiElements(parseResult, filename))
   )
 
@@ -324,7 +324,7 @@ describe('compileFromApiElements()', ->
 
       options = {type: 'refract', generateSourceMap: true}
       protagonist.parse(apiDescriptionDocument, options, (err, parseResult) ->
-        return done(err) unless parseResult
+        return done(err) if err
         {warnings, transactions} = stubbedCompileFromApiElements(parseResult, null)
         done()
       )
@@ -444,7 +444,7 @@ describe('compileFromApiElements()', ->
 
       options = {type: 'refract', generateSourceMap: true}
       protagonist.parse(apiDescriptionDocument, options, (err, parseResult) ->
-        return done(err) unless parseResult
+        return done(err) if err
         {warnings, transactions} = stubbedCompileFromApiElements(parseResult, null)
         done()
       )


### PR DESCRIPTION
- Addressing apiaryio/dredd#469 and apiaryio/dredd#478. Verified that Dredd with linked `dredd-transactions` containing changes from this PR behaves correctly and doesn't crash.
- Removed warning about unused URI parameters as parser started to provide the very same warning.