### PR TITLE
Ability to consume Swagger input

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "clone": "^1.0.2",
     "fury": "^2.1.0",
     "fury-adapter-apib-parser": "^0.2.0",
+    "fury-adapter-swagger": "^0.8.0-pre.7",
     "sift": "^3.2.1",
     "traverse": "^0.6.6",
     "uri-template": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "clone": "^1.0.2",
-    "fury": "^2.0.0",
+    "fury": "^2.1.0",
     "fury-adapter-apib-parser": "^0.2.0",
     "sift": "^3.2.1",
     "traverse": "^0.6.6",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   },
   "dependencies": {
     "clone": "^1.0.2",
-    "protagonist": "^1.3.2",
+    "fury": "^2.0.0",
+    "fury-adapter-apib-parser": "^0.2.0",
     "sift": "^3.2.1",
     "traverse": "^0.6.6",
     "uri-template": "^1.0.0"
@@ -32,6 +33,7 @@
     "jscoverage": "^0.6.0",
     "mocha": "^2.3.4",
     "mocha-lcov-reporter": "^1.0.0",
+    "protagonist": "",
     "proxyquire": "^1.7.4",
     "sinon": "^1.17.3",
     "tv4": "^1.2.7"

--- a/src/detect-transaction-examples.coffee
+++ b/src/detect-transaction-examples.coffee
@@ -62,7 +62,7 @@ createIndex = (transition) ->
   traversal = traverse(transition)
   traversal.forEach((node) ->
     # Process just sourceMap elements.
-    return unless node.element is 'sourceMap'
+    return unless node?.element is 'sourceMap'
 
     # Ignore sourceMap elements for request's HTTP method. Method is
     # often on a different place in the document than the actual

--- a/src/expand-uri-template-with-parameters.coffee
+++ b/src/expand-uri-template-with-parameters.coffee
@@ -5,6 +5,7 @@ expandUriTemplateWithParameters = (uriTemplate, parameters) ->
     errors: []
     warnings: []
     uri: null
+
   try
     parsed = ut.parse uriTemplate
   catch e

--- a/src/parse.coffee
+++ b/src/parse.coffee
@@ -1,6 +1,7 @@
 
 fury = require('fury')
 fury.use(require('fury-adapter-apib-parser'))
+fury.use(require('fury-adapter-swagger'))
 
 
 parse = (source, callback) ->

--- a/src/parse.coffee
+++ b/src/parse.coffee
@@ -1,18 +1,26 @@
 
-protagonist = require('protagonist')
+fury = require('fury')
+fury.use(require('fury-adapter-apib-parser'))
 
 
-parse = (apiDescriptionDocument, callback) ->
-  options = {generateSourceMap: true}
-  protagonist.parse(apiDescriptionDocument, options, (err, result) ->
+parse = (source, callback) ->
+  fury.parse({source, generateSourceMap: true}, (err, result) ->
     if not (err or result)
       err = new Error('Unexpected parser error occurred.')
     else if err
-      # Turning Protagonist error object into standard JavaScript error
+      # Turning Fury error object into standard JavaScript error
       err = new Error(err.message)
 
-    # If no parse result is present, indicate that with 'null', not 'undefined'
-    callback(err, result or null)
+    if result
+      # Due to bug https://github.com/apiaryio/fury.js/pull/60 Fury sometimes
+      # returns plain Refract instead of Minim-wrapped Refract.
+      result = result.toRefract() if result.toRefract
+    else
+      # If no parse result is present, indicate that with 'null',
+      # not with 'undefined'.
+      result = null
+
+    callback(err, result)
   )
 
 

--- a/src/parse.coffee
+++ b/src/parse.coffee
@@ -11,16 +11,9 @@ parse = (source, callback) ->
       # Turning Fury error object into standard JavaScript error
       err = new Error(err.message)
 
-    if result
-      # Due to bug https://github.com/apiaryio/fury.js/pull/60 Fury sometimes
-      # returns plain Refract instead of Minim-wrapped Refract.
-      result = result.toRefract() if result.toRefract
-    else
-      # If no parse result is present, indicate that with 'null',
-      # not with 'undefined'.
-      result = null
-
-    callback(err, result)
+    # If no parse result is present, indicate that with 'null',
+    # not with 'undefined'.
+    callback(err, (if result then result.toRefract() else null))
   )
 
 

--- a/src/refract.coffee
+++ b/src/refract.coffee
@@ -17,7 +17,11 @@ children = (node, query, options = {}) ->
   sifter = sift(query or {})
 
   traverse(node).forEach((childNode) ->
-    if childNode isnt node and childNode.element and sifter(childNode)
+    if (
+      childNode?.element and # we want only element nodes (node can be 'undefined' if it represents empty 'content')
+      childNode isnt node and # we don't count given node as it's own child
+      sifter(childNode) # filtering by given conditions
+    )
       results.push(childNode)
       @stop() if options.first
     return # needed for 'traverse' to work properly in CoffeeScript

--- a/test/integration/dredd-transactions-test.coffee
+++ b/test/integration/dredd-transactions-test.coffee
@@ -1,7 +1,8 @@
-protagonist = require 'protagonist'
+
 {assert} = require 'chai'
 
 dreddTransactions = require '../../src/dredd-transactions'
+
 
 describe "compiled transaction paths", ->
   describe "Full notation with multiple request-response pairs", ->

--- a/test/unit/dredd-transactions-test.coffee
+++ b/test/unit/dredd-transactions-test.coffee
@@ -2,7 +2,6 @@ proxyquire = require('proxyquire').noPreserveCache()
 fs = require 'fs'
 path = require 'path'
 {assert} = require 'chai'
-protagonist = require 'protagonist'
 sinon = require 'sinon'
 dreddTransactions = require '../../src/dredd-transactions'
 ast = require '../fixtures/blueprint-ast'

--- a/test/unit/parse-test.coffee
+++ b/test/unit/parse-test.coffee
@@ -2,7 +2,7 @@
 fs = require('fs')
 path = require('path')
 sinon = require('sinon')
-protagonist = require('protagonist')
+fury = require('fury')
 {assert} = require('chai')
 
 parse = require('../../src/parse')
@@ -104,7 +104,7 @@ describe('Parsing API description document', ->
     parseResult = undefined
 
     beforeEach((done) ->
-      sinon.stub(protagonist, 'parse', (args...) ->
+      sinon.stub(fury, 'parse', (args...) ->
         args.pop()() # calling the callback with neither error or parse result
       )
       parse('... dummy API description document ...', (args...) ->
@@ -113,7 +113,7 @@ describe('Parsing API description document', ->
       )
     )
     afterEach( ->
-      protagonist.parse.restore()
+      fury.parse.restore()
     )
 
     it('produces error', ->


### PR DESCRIPTION
This PR removes `protagonist` as a parser binding from most places in Dredd Transactions and replaces it with the latest Fury and its API Blueprint parser adapter.

Then, Swagger adapter is added so Dredd Transactions can accept also Swagger input. This is backwards compatible change. When feeded with Swagger, behaviour of Dredd Transactions now isn't _erroneous_ anymore, but rather _undefined_.

Part of https://github.com/apiaryio/dredd/issues/389.
