### PR TITLE
Fix how errors are handled

### DIFF
--- a/src/dredd-transactions.coffee
+++ b/src/dredd-transactions.coffee
@@ -6,7 +6,24 @@ getTransactionPath = require('./transaction-path/get-transaction-path')
 
 
 compile = (input, filename, callback) ->
+  # All regular parser-related or compilation-related errors and warnings
+  # should be returned in the "compilation result". Callback should get
+  # an error only in case of unexpected crash.
+
   parse(input, (err, apiElements) ->
+    # If 'apiElements' isn't empty, then we don't need to care about 'err'
+    # as it should be represented by annotation inside 'apiElements'
+    # and compilation should be able to deal with it and propagate it.
+    if err and not apiElements
+      compilationResult = {transactions: [], warnings: [], errors: [
+        component: 'apiDescriptionParser'
+        message: err.message
+      ]}
+      return callback(null, compilationResult)
+
+    # The try/catch is just to deal with unexpected crash. Compilation passes
+    # all errors as part of the 'result' and it should not throw anything
+    # in any case.
     try
       result = compileFromApiElements(apiElements, filename)
     catch err

--- a/test/unit/dredd-transactions-test.coffee
+++ b/test/unit/dredd-transactions-test.coffee
@@ -58,7 +58,7 @@ describe 'dreddTransactions', ->
 
     filename = '... dummy filename ...'
     apiDescriptionDocument = '''
-      # Dummy API
+      FORMAT: 1A
       ... dummy API Description ...
     '''
     callbackArguments = undefined


### PR DESCRIPTION
Dealing with 'unknown API description format' error. Added some integration tests for this. Added comments to explain all the intended behavior.