### PR TITLE
Load unrecognized API description documents as API Blueprint

### DIFF
--- a/test/fixtures/api-blueprint/unrecognizable.apib
+++ b/test/fixtures/api-blueprint/unrecognizable.apib
@@ -1,0 +1,16 @@
+# Sample API
+
+# Data Structures
+
+## Coupon Base (object)
++ percent_off: 25 (number)
+
+    A positive integer between 1 and 100 that represents the discount the
+    coupon will apply.
+
++ redeem_by (number) - Date after which the coupon can no longer be redeemed
+
+# GET /message
++ Response (text/plain)
+
+        Hello World!

--- a/test/fixtures/index.coffee
+++ b/test/fixtures/index.coffee
@@ -110,6 +110,9 @@ fixtures =
   )
 
   # Specific to API Blueprint
+  unrecognizable: fixture(
+    apiBlueprint: fromFile('./api-blueprint/unrecognizable.apib')
+  )
   missingTitleAnnotation: fixture(
     apiBlueprint: fromFile('./api-blueprint/missing-title-annotation.apib')
   )

--- a/test/integration/dredd-transactions-test.coffee
+++ b/test/integration/dredd-transactions-test.coffee
@@ -26,7 +26,10 @@ describe('Dredd Transactions', ->
         assert.jsonSchema(compilationResult, schema)
       )
       it('produces warning about falling back to API Blueprint', ->
-        assert.include(compilationResult.warnings[0].message, 'to API Blueprint')
+        assert.include(
+          JSON.stringify(compilationResult.warnings),
+          'to API Blueprint'
+        )
       )
     )
   )
@@ -35,7 +38,7 @@ describe('Dredd Transactions', ->
     compilationResult = undefined
     schema = createCompilationResultSchema(
       errors: 0
-      warnings: 1
+      warnings: true
       transactions: 0
     )
     source = '''
@@ -53,7 +56,10 @@ describe('Dredd Transactions', ->
       assert.jsonSchema(compilationResult, schema)
     )
     it('produces warning about falling back to API Blueprint', ->
-      assert.include(compilationResult.warnings[0].message, 'to API Blueprint')
+      assert.include(
+        JSON.stringify(compilationResult.warnings),
+        'to API Blueprint'
+      )
     )
   )
 
@@ -77,7 +83,10 @@ describe('Dredd Transactions', ->
       assert.jsonSchema(compilationResult, schema)
     )
     it('produces warning about falling back to API Blueprint', ->
-      assert.include(compilationResult.warnings[0].message, 'to API Blueprint')
+      assert.include(
+        JSON.stringify(compilationResult.warnings),
+        'to API Blueprint'
+      )
     )
   )
 

--- a/test/integration/dredd-transactions-test.coffee
+++ b/test/integration/dredd-transactions-test.coffee
@@ -9,8 +9,8 @@ describe('Dredd Transactions', ->
   describe('When given no input', ->
     compilationResult = undefined
     schema = createCompilationResultSchema(
-      errors: 1
-      warnings: 0
+      errors: 0
+      warnings: 1
       transactions: 0
     )
 
@@ -22,8 +22,11 @@ describe('Dredd Transactions', ->
         )
       )
 
-      it('produces one error, no warnings, no transactions', ->
+      it('produces no errors, one warning, no transactions', ->
         assert.jsonSchema(compilationResult, schema)
+      )
+      it('produces warning about falling back to API Blueprint', ->
+        assert.include(compilationResult.warnings[0].message, 'to API Blueprint')
       )
     )
   )
@@ -31,8 +34,8 @@ describe('Dredd Transactions', ->
   describe('When given unknown API description format', ->
     compilationResult = undefined
     schema = createCompilationResultSchema(
-      errors: 1
-      warnings: 0
+      errors: 0
+      warnings: 1
       transactions: 0
     )
     source = '''
@@ -46,12 +49,39 @@ describe('Dredd Transactions', ->
       )
     )
 
-    it('produces one error, no warnings, no transactions', ->
+    it('produces no errors, one warning, no transactions', ->
       assert.jsonSchema(compilationResult, schema)
+    )
+    it('produces warning about falling back to API Blueprint', ->
+      assert.include(compilationResult.warnings[0].message, 'to API Blueprint')
     )
   )
 
-  describe('When given erroneous API description', ->
+  describe('When given unrecognizable API Blueprint format', ->
+    compilationResult = undefined
+    schema = createCompilationResultSchema(
+      errors: 0
+      warnings: true
+      transactions: true
+    )
+    source = fixtures.unrecognizable.apiBlueprint
+
+    beforeEach((done) ->
+      dreddTransactions.compile(source, null, (args...) ->
+        [err, compilationResult] = args
+        done(err)
+      )
+    )
+
+    it('produces no errors, some warnings, some transactions', ->
+      assert.jsonSchema(compilationResult, schema)
+    )
+    it('produces warning about falling back to API Blueprint', ->
+      assert.include(compilationResult.warnings[0].message, 'to API Blueprint')
+    )
+  )
+
+  describe('When given API description with errors', ->
     compilationResult = undefined
     schema = createCompilationResultSchema(
       errors: true
@@ -73,12 +103,12 @@ describe('Dredd Transactions', ->
     )
   )
 
-  describe('When given API description with warning', ->
+  describe('When given API description with warnings', ->
     compilationResult = undefined
     schema = createCompilationResultSchema(
       errors: 0
       warnings: true
-      transactions: 1
+      transactions: true
     )
 
     fixtures.parserWarning.forEachDescribe(({source}) ->
@@ -89,7 +119,7 @@ describe('Dredd Transactions', ->
         )
       )
 
-      it('produces no errors, some warnings, one transaction', ->
+      it('produces no errors, some warnings, some transactions', ->
         assert.jsonSchema(compilationResult, schema)
       )
     )

--- a/test/unit/parse-test.coffee
+++ b/test/unit/parse-test.coffee
@@ -120,4 +120,60 @@ describe('Parsing API description document', ->
       assert.isNull(parseResult)
     )
   )
+
+  describe('Completely unknown document format is treated as API Blueprint', ->
+    error = undefined
+    parseResult = undefined
+
+    beforeEach((done) ->
+      parse('... dummy API description document ...', (args...) ->
+        [error, parseResult] = args
+        done()
+      )
+    )
+
+    it('produces no error', ->
+      assert.isNull(error)
+    )
+    it('produces parse result', ->
+      assert.isObject(parseResult)
+    )
+    it('the parse result contains annotation element', ->
+      assert.include(JSON.stringify(parseResult), '"annotation"')
+    )
+    it('the annotation is a warning', ->
+      assert.include(JSON.stringify(parseResult), '"warning"')
+    )
+    it('the warning is about falling back to API Blueprint', ->
+      assert.include(JSON.stringify(parseResult), 'to API Blueprint')
+    )
+  )
+
+  describe('Unrecognizable API Blueprint is treated as API Blueprint', ->
+    error = undefined
+    parseResult = undefined
+
+    beforeEach((done) ->
+      parse(fixtures.unrecognizable.apiBlueprint, (args...) ->
+        [error, parseResult] = args
+        done()
+      )
+    )
+
+    it('produces no error', ->
+      assert.isNull(error)
+    )
+    it('produces parse result', ->
+      assert.isObject(parseResult)
+    )
+    it('the parse result contains annotation element', ->
+      assert.include(JSON.stringify(parseResult), '"annotation"')
+    )
+    it('the annotation is a warning', ->
+      assert.include(JSON.stringify(parseResult), '"warning"')
+    )
+    it('the warning is about falling back to API Blueprint', ->
+      assert.include(JSON.stringify(parseResult), 'to API Blueprint')
+    )
+  )
 )


### PR DESCRIPTION
This is to make the behavior backwards compatible. This PR depends on https://github.com/apiaryio/dredd-transactions/pull/34 and needs to be rebased once it's merged.