### PR TITLE
Transaction names only for API Blueprint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dredd-transactions",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Compiles HTTP Transactions (Request-Response pairs) from API description document",
   "main": "lib/dredd-transactions.js",
   "scripts": {

--- a/src/compile.coffee
+++ b/src/compile.coffee
@@ -7,7 +7,7 @@ detectTransactionExamples = require('./detect-transaction-examples')
 expandUriTemplateWithParameters = require('./expand-uri-template-with-parameters')
 
 
-compile = (parseResult, filename) ->
+compile = (mediaType, parseResult, filename) ->
   transactions = []
   errors = []
   warnings = []
@@ -22,7 +22,8 @@ compile = (parseResult, filename) ->
       location: content(child(annotation.attributes?.sourceMap, {element: 'sourceMap'}))
     })
 
-  children(parseResult, {element: 'transition'}).map(detectTransactionExamples)
+  if mediaType is 'text/vnd.apiblueprint'
+    children(parseResult, {element: 'transition'}).map(detectTransactionExamples)
 
   for httpTransaction in children(parseResult, {element: 'httpTransaction'})
     resource = parent(httpTransaction, parseResult, {element: 'resource'})

--- a/src/dredd-transactions.coffee
+++ b/src/dredd-transactions.coffee
@@ -27,7 +27,7 @@ compile = (input, filename, callback) ->
     # in any case.
     try
       {mediaType, apiElements} = parseResult
-      result = compileFromApiElements(apiElements, filename)
+      result = compileFromApiElements(mediaType, apiElements, filename)
     catch err
       return callback(err)
 

--- a/test/fixtures/index.coffee
+++ b/test/fixtures/index.coffee
@@ -142,6 +142,9 @@ fixtures =
   consumes: fixture(
     swagger: fromFile('./swagger/consumes.yml')
   )
+  multipleResponses: fixture(
+    swagger: fromFile('./swagger/multiple-responses.yml')
+  )
 
 
 module.exports = fixtures

--- a/test/fixtures/swagger/multiple-responses.yml
+++ b/test/fixtures/swagger/multiple-responses.yml
@@ -1,0 +1,40 @@
+swagger: "2.0"
+info:
+  version: "1.0"
+  title: Beehive API
+consumes:
+  - application/json
+produces:
+  - application/xml
+  - application/json
+paths:
+  /honey:
+    get:
+      responses:
+        200:
+          description: pet response
+          headers:
+            X-Test:
+              type: string
+              enum:
+                - Adam
+                - Pavan
+          schema:
+            $ref: '#/definitions/Bee'
+        400:
+          description: user error
+        500:
+          description: server error
+definitions:
+  Bee:
+    required:
+      - id
+      - name
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+      tag:
+        type: string

--- a/test/unit/compilation/compile-api-blueprint-test.coffee
+++ b/test/unit/compilation/compile-api-blueprint-test.coffee
@@ -1,4 +1,7 @@
 
+proxyquire = require('proxyquire').noPreserveCache()
+sinon = require('sinon')
+
 fixtures = require('../../fixtures')
 createLocationSchema = require('../../schemas/location')
 createOriginSchema = require('../../schemas/origin')
@@ -86,17 +89,23 @@ describe('compile() · API Blueprint', ->
   )
 
   describe('with multiple transaction examples', ->
+    detectTransactionExamples = sinon.spy(require('../../../src/detect-transaction-examples'))
     transactions = undefined
     exampleNumbersPerTransaction = [1, 1, 2]
 
     beforeEach((done) ->
-      compileFixture(fixtures.multipleTransactionExamples.apiBlueprint, (args...) ->
+      stubs = {'./detect-transaction-examples': detectTransactionExamples}
+
+      compileFixture(fixtures.multipleTransactionExamples.apiBlueprint, {stubs}, (args...) ->
         [err, compilationResult] = args
         transactions = compilationResult.transactions
         done(err)
       )
     )
 
+    it('detection of transaction examples was called', ->
+      assert.isTrue(detectTransactionExamples.called)
+    )
     it('is compiled into expected number of transactions', ->
       assert.equal(transactions.length, exampleNumbersPerTransaction.length)
     )
@@ -113,17 +122,23 @@ describe('compile() · API Blueprint', ->
   )
 
   describe('without multiple transaction examples', ->
+    detectTransactionExamples = sinon.spy(require('../../../src/detect-transaction-examples'))
     compilationResult = undefined
     transaction = undefined
 
     beforeEach((done) ->
-      compileFixture(fixtures.oneTransactionExample.apiBlueprint, (args...) ->
+      stubs = {'./detect-transaction-examples': detectTransactionExamples}
+
+      compileFixture(fixtures.oneTransactionExample.apiBlueprint, {stubs}, (args...) ->
         [err, compilationResult] = args
         transaction = compilationResult.transactions[0]
         done(err)
       )
     )
 
+    it('detection of transaction examples was called', ->
+      assert.isTrue(detectTransactionExamples.called)
+    )
     it('is compiled into one transaction', ->
       assert.equal(compilationResult.transactions.length, 1)
     )

--- a/test/unit/compilation/compile-swagger-test.coffee
+++ b/test/unit/compilation/compile-swagger-test.coffee
@@ -1,4 +1,6 @@
 
+sinon = require('sinon')
+
 fixtures = require('../../fixtures')
 {assert, compileFixture} = require('../../utils')
 createLocationSchema = require('../../schemas/location')
@@ -89,6 +91,29 @@ describe('compile() · Swagger', ->
       it('with expected response headers', ->
         assert.deepEqual(response.headers, {})
       )
+    )
+  )
+
+  describe('with multiple responses', ->
+    # Multiple responses is the closest we can get with Swagger to something
+    # like transaction examples ¯\_(ツ)_/¯
+
+    detectTransactionExamples = sinon.spy(require('../../../src/detect-transaction-examples'))
+    compilationResult = undefined
+    transaction = undefined
+
+    beforeEach((done) ->
+      stubs = {'./detect-transaction-examples': detectTransactionExamples}
+
+      compileFixture(fixtures.multipleResponses.swagger, {stubs}, (args...) ->
+        [err, compilationResult] = args
+        transaction = compilationResult.transactions[0]
+        done(err)
+      )
+    )
+
+    it('detection of transaction examples was not called', ->
+      assert.isFalse(detectTransactionExamples.called)
     )
   )
 )

--- a/test/utils.coffee
+++ b/test/utils.coffee
@@ -22,7 +22,8 @@ compileFixture = (source, options, done) ->
     # appear in the `parseResult` too in form of annotations and we're testing
     # whether the compilation is able to deal with them.
     try
-      result = compile(parseResult, options.filename)
+      {mediaType, apiElements} = parseResult
+      result = compile(mediaType, apiElements, options.filename)
       done(null, result)
     catch err
       done(err)


### PR DESCRIPTION
Tests ensuring that transaction examples won't appear in transaction names if Swagger is used.