### PR TITLE
Remove JS/CPP testing matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,6 @@ env:
   global:
     # GH_TOKEN and NPM_TOKEN encrypted by 'travis encrypt' utility
     - secure: "LWRVV2vXBEMPdLGmcOe25t2iE/k7CuONnNsmyCUCSusybVwh/wDwKNOYT+TqEegD34u5dkhfPuMy+sEn1IKUgTBIxjI6cXSbyLEmVBJuoEKySZaPUaXFeqylLgy8Q/vjPv0m9WQGPx94KIT0uPPB0KS1+ApRssksBeSp1TgQ7zXxssR9+5Ym0wdQSmHjajqjIEGJ3+L7IUANZinOfzh76V5d3MtDxHjKA570nGat0bXJ54Sy9G/a23c4HB+qNgneQPAkwbrK19LsMNeOUVLzCTt4RHuqOtg/EBgcR88HGfzzWYiuqXNqO+tqacV00cZZ6qIsvTw8zidE1YSpPvoIMfiEf1887+RQjPGSEnFssv8a0G9JjAN478OmpBWFTMsiaOyd8cckgb2ZApMXxZQch5l35Qr23zIa1JKgEWeoz25G5dGGJPfVyjWfyZhLDRtNPuq1TSBoQT9nGH35NEOYCSCWcwgFWn9aYeSNdxSMrb62GpLspPJIO8QXD3mTtn69TBa5Mn3o3MvP+NJ9l1uyv14WtF+Um4IMH8BDwdWLxjG1dwrK5kOskfo0ioSfK1u2lE3YaW9ARDTbOf2FAluqCCdld9XZStH7pIW8SBJtIwQYA0P+CyVYnvBQqxw3rbW2Sn1VwYw7hzoAHpzlI68tKEhjgIybsCZNFbaU3NNcjr4="
-  matrix:
-    - "DRAFTER=JS"
-    - "DRAFTER=CPP"
 cache:
   directories:
     - "node_modules"
@@ -21,7 +18,6 @@ before_install:
 before_script:
   - "npm run lint"
 script:
-  - "if [[ $DRAFTER = JS ]]; then find ./node_modules -name protagonist -type d -exec rm -rf {} +; fi"
   - "npm test"
 after_success:  # travis_after_all.py is needed due to travis-ci/travis-ci#1548 & travis-ci/travis-ci#929
   - "npm run coveralls"


### PR DESCRIPTION
It has been one month of testing both versions of Drafter and there has been no issues. I'm removing the matrix so our tests can run two times faster again.