### PR TITLE
Use just the 1st req-res pair within APIB transaction examples

### DIFF
--- a/test/fixtures/api-blueprint/multiple-transaction-examples.apib
+++ b/test/fixtures/api-blueprint/multiple-transaction-examples.apib
@@ -4,6 +4,12 @@ FORMAT: 1A
 
 ## Honey [/honey]
 
+### Retrieve [GET]
+
++ Request (application/json)
++ Response 200
++ Response 500
+
 ### Remove [DELETE]
 
 + Request (application/json)
@@ -11,4 +17,5 @@ FORMAT: 1A
 + Response 500
 
 + Request (text/plain)
++ Request (application/xml)
 + Response 415

--- a/test/integration/compile-api-blueprint-test.coffee
+++ b/test/integration/compile-api-blueprint-test.coffee
@@ -91,7 +91,11 @@ describe('compile() · API Blueprint', ->
   describe('with multiple transaction examples', ->
     detectTransactionExamples = sinon.spy(require('../../src/detect-transaction-examples'))
     transactions = undefined
-    exampleNumbersPerTransaction = [1, 1, 2]
+    expected = [
+      {exampleName: '', requestContentType: 'application/json', responseStatusCode: 200}
+      {exampleName: 'Example 1', requestContentType: 'application/json', responseStatusCode: 200}
+      {exampleName: 'Example 2', requestContentType: 'text/plain', responseStatusCode: 415}
+    ]
 
     beforeEach((done) ->
       stubs = {'./detect-transaction-examples': detectTransactionExamples}
@@ -107,15 +111,29 @@ describe('compile() · API Blueprint', ->
       assert.isTrue(detectTransactionExamples.called)
     )
     it('is compiled into expected number of transactions', ->
-      assert.equal(transactions.length, exampleNumbersPerTransaction.length)
+      assert.equal(transactions.length, expected.length)
     )
-    for exampleNumber, i in exampleNumbersPerTransaction
-      do (exampleNumber, i) ->
+    for expectations, i in expected
+      do (expectations, i) ->
         context("transaction ##{i + 1}", ->
-          it("is identified as part of Example #{exampleNumber}", ->
+          {exampleName, requestContentType, responseStatusCode} = expectations
+
+          it("is identified as part of #{JSON.stringify(exampleName)}", ->
             assert.equal(
               transactions[i].origin.exampleName,
-              "Example #{exampleNumber}"
+              exampleName
+            )
+          )
+          it("has request with Content-Type: #{requestContentType}", ->
+            assert.equal(
+              transactions[i].request.headers['Content-Type'].value,
+              requestContentType
+            )
+          )
+          it("has response with status code #{responseStatusCode}", ->
+            assert.equal(
+              transactions[i].response.status,
+              responseStatusCode
             )
           )
         )


### PR DESCRIPTION
**BREAKING CHANGE**

This change fixes a problem introduced with migration to API Elements in order to support Swagger in Dredd. Original implementation always selected the first request-response pair from each transaction example. This wasn't re-implemented correctly on top of API Elements. Instead, all specified responses are appearing, which breaks Dredd's behavior in many ways. Respective test was ported, but unfortunately with the same mistake.

Some early adopters discovered the issue and considered it to be a new feature, but it really breaks how Dredd should work at the moment and needs to be removed. It leads to duplicate transaction names and other undefined behavior.

In order to implement https://github.com/apiaryio/dredd/issues/25 and https://github.com/apiaryio/dredd/issues/78, which many believed happened when they discovered the bug, much more work needs to be done. Namely designing and adopting a new way of addressing transactions in Dredd https://github.com/apiaryio/dredd/issues/227.