### PR TITLE
Unique transaction names for Swagger

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/apiaryio/dredd-transactions"
   },
   "dependencies": {
+    "caseless": "^0.11.0",
     "clone": "^1.0.2",
     "deckardcain": "^0.3.2",
     "fury": "^2.1.0",

--- a/src/compile.coffee
+++ b/src/compile.coffee
@@ -1,5 +1,6 @@
 
 clone = require('clone')
+caseless = require('caseless')
 
 {child, children, parent, content} = require('./refract')
 validateParameters = require('./validate-parameters')
@@ -27,7 +28,7 @@ compile = (mediaType, parseResult, filename) ->
     httpRequest = child(httpTransaction, {element: 'httpRequest'})
     httpResponse = child(httpTransaction, {element: 'httpResponse'})
 
-    origin = compileOrigin(filename, parseResult, httpTransaction)
+    origin = compileOrigin(filename, parseResult, mediaType, httpTransaction)
     {request, annotations} = compileRequest(parseResult, httpRequest)
 
     if request
@@ -184,17 +185,12 @@ compileHeaders = (httpHeaders) ->
   headers
 
 
-compileOrigin = (filename, parseResult, httpTransaction) ->
+compileOrigin = (filename, parseResult, mediaType, httpTransaction) ->
   api = parent(httpTransaction, parseResult, {element: 'category', 'meta.classes': 'api'})
   resourceGroup = parent(httpTransaction, parseResult, {element: 'category', 'meta.classes': 'resourceGroup'})
   resource = parent(httpTransaction, parseResult, {element: 'resource'})
   transition = parent(httpTransaction, parseResult, {element: 'transition'})
   httpRequest = child(httpTransaction, {element: 'httpRequest'})
-
-  if content(transition.attributes.examples) > 1
-    exampleName = "Example #{httpTransaction.attributes.example}"
-  else
-    exampleName = ''
 
   {
     filename: filename or ''
@@ -202,7 +198,7 @@ compileOrigin = (filename, parseResult, httpTransaction) ->
     resourceGroupName: content(resourceGroup?.meta?.title) or ''
     resourceName: content(resource.meta?.title) or content(resource.attributes?.href) or ''
     actionName: content(transition.meta?.title) or content(httpRequest.attributes.method) or ''
-    exampleName
+    exampleName: compileOriginExampleName(parseResult, mediaType, httpTransaction)
   }
 
 
@@ -220,6 +216,28 @@ compilePathOrigin = (filename, parseResult, httpTransaction) ->
     actionName: content(transition.meta?.title) or content(httpRequest.attributes.method) or ''
     exampleName: "Example #{httpTransaction.attributes.example}"
   }
+
+
+compileOriginExampleName = (parseResult, mediaType, httpTransaction) ->
+  exampleName = ''
+
+  transition = parent(httpTransaction, parseResult, {element: 'transition'})
+  httpResponse = child(httpTransaction, {element: 'httpResponse'})
+
+  if mediaType is 'text/vnd.apiblueprint'
+    if content(transition.attributes.examples) > 1
+      exampleName = "Example #{httpTransaction.attributes.example}"
+  else
+    statusCode = content(httpResponse.attributes.statusCode)
+    headers = compileHeaders(child(httpResponse, {element: 'httpHeaders'}))
+    contentType = caseless(headers).get('content-type')?.value
+
+    segments = []
+    segments.push(statusCode) if statusCode
+    segments.push(contentType) if contentType
+    exampleName = segments.join(' > ')
+
+  return exampleName
 
 
 module.exports = compile

--- a/src/compile.coffee
+++ b/src/compile.coffee
@@ -219,10 +219,10 @@ compilePathOrigin = (parseResult, filename, httpTransaction) ->
 
 
 compileOriginExampleName = (mediaType, parseResult, httpTransaction) ->
-  exampleName = ''
-
   transition = parent(httpTransaction, parseResult, {element: 'transition'})
   httpResponse = child(httpTransaction, {element: 'httpResponse'})
+
+  exampleName = ''
 
   if mediaType is 'text/vnd.apiblueprint'
     if content(transition.attributes.examples) > 1

--- a/src/compile.coffee
+++ b/src/compile.coffee
@@ -23,18 +23,18 @@ compile = (mediaType, parseResult, filename) ->
       location: content(child(annotation.attributes?.sourceMap, {element: 'sourceMap'}))
     })
 
-  for httpTransaction in findRelevantTransactions(parseResult, mediaType)
+  for httpTransaction in findRelevantTransactions(mediaType, parseResult)
     resource = parent(httpTransaction, parseResult, {element: 'resource'})
     httpRequest = child(httpTransaction, {element: 'httpRequest'})
     httpResponse = child(httpTransaction, {element: 'httpResponse'})
 
-    origin = compileOrigin(filename, parseResult, mediaType, httpTransaction)
+    origin = compileOrigin(mediaType, parseResult, filename, httpTransaction)
     {request, annotations} = compileRequest(parseResult, httpRequest)
 
     if request
       transactions.push({
         origin
-        pathOrigin: compilePathOrigin(filename, parseResult, httpTransaction)
+        pathOrigin: compilePathOrigin(parseResult, filename, httpTransaction)
         request
         response: compileResponse(httpResponse)
       })
@@ -49,7 +49,7 @@ compile = (mediaType, parseResult, filename) ->
   {transactions, errors, warnings}
 
 
-findRelevantTransactions = (parseResult, mediaType) ->
+findRelevantTransactions = (mediaType, parseResult) ->
   relevantTransactions = []
 
   if mediaType is 'text/vnd.apiblueprint'
@@ -185,7 +185,7 @@ compileHeaders = (httpHeaders) ->
   headers
 
 
-compileOrigin = (filename, parseResult, mediaType, httpTransaction) ->
+compileOrigin = (mediaType, parseResult, filename, httpTransaction) ->
   api = parent(httpTransaction, parseResult, {element: 'category', 'meta.classes': 'api'})
   resourceGroup = parent(httpTransaction, parseResult, {element: 'category', 'meta.classes': 'resourceGroup'})
   resource = parent(httpTransaction, parseResult, {element: 'resource'})
@@ -198,11 +198,11 @@ compileOrigin = (filename, parseResult, mediaType, httpTransaction) ->
     resourceGroupName: content(resourceGroup?.meta?.title) or ''
     resourceName: content(resource.meta?.title) or content(resource.attributes?.href) or ''
     actionName: content(transition.meta?.title) or content(httpRequest.attributes.method) or ''
-    exampleName: compileOriginExampleName(parseResult, mediaType, httpTransaction)
+    exampleName: compileOriginExampleName(mediaType, parseResult, httpTransaction)
   }
 
 
-compilePathOrigin = (filename, parseResult, httpTransaction) ->
+compilePathOrigin = (parseResult, filename, httpTransaction) ->
   api = parent(httpTransaction, parseResult, {element: 'category', 'meta.classes': 'api'})
   resourceGroup = parent(httpTransaction, parseResult, {element: 'category', 'meta.classes': 'resourceGroup'})
   resource = parent(httpTransaction, parseResult, {element: 'resource'})
@@ -218,7 +218,7 @@ compilePathOrigin = (filename, parseResult, httpTransaction) ->
   }
 
 
-compileOriginExampleName = (parseResult, mediaType, httpTransaction) ->
+compileOriginExampleName = (mediaType, parseResult, httpTransaction) ->
   exampleName = ''
 
   transition = parent(httpTransaction, parseResult, {element: 'transition'})

--- a/test/integration/compile-swagger-test.coffee
+++ b/test/integration/compile-swagger-test.coffee
@@ -96,23 +96,19 @@ describe('compile() · Swagger', ->
     )
   )
 
-  describe.only('with multiple responses', ->
+  describe('with multiple responses', ->
     transactions = undefined
     filename = 'apiDescription.json'
     detectTransactionExamples = sinon.spy(require('../../src/detect-transaction-examples'))
 
-    expected = [
-      {status: 200}
-      {status: 400}
-      {status: 500}
-    ]
+    expectedStatusCodes = [200, 400, 500]
 
     beforeEach((done) ->
       stubs = {'./detect-transaction-examples': detectTransactionExamples}
 
       compileFixture(fixtures.multipleResponses.swagger, {filename, stubs}, (args...) ->
         [err, compilationResult] = args
-        transactions = compilationResult.transactions
+        transactions = compilationResult?.transactions
         done(err)
       )
     )
@@ -121,11 +117,11 @@ describe('compile() · Swagger', ->
       assert.isFalse(detectTransactionExamples.called)
     )
     it('expected number of transactions was returned', ->
-      assert.equal(transactions.length, expected.length)
+      assert.equal(transactions.length, expectedStatusCodes.length)
     )
 
-    for expectations, i in expected
-      do (expectations, i) ->
+    for statusCode, i in expectedStatusCodes
+      do (statusCode, i) ->
         context("origin of transaction ##{i + 1}", ->
           it('uses URI as resource name', ->
             assert.equal(transactions[i].origin.resourceName, '/honey')
@@ -133,14 +129,11 @@ describe('compile() · Swagger', ->
           it('uses method as action name', ->
             assert.equal(transactions[i].origin.actionName, 'GET')
           )
-        )
-
-        context("pathOrigin of transaction ##{i + 1}", ->
-          it('uses URI as resource name', ->
-            assert.equal(transactions[i].pathOrigin.resourceName, '/honey')
-          )
-          it('uses method as action name', ->
-            assert.equal(transactions[i].pathOrigin.actionName, 'GET')
+          it('uses status code and response\'s Content-Type as example name', ->
+            assert.equal(
+              transactions[i].origin.exampleName,
+              "#{statusCode} > application/json"
+            )
           )
         )
   )

--- a/test/unit/transaction-name/get-transaction-name-test.coffee
+++ b/test/unit/transaction-name/get-transaction-name-test.coffee
@@ -5,3 +5,36 @@ getTransactionName = require '../../../src/transaction-name/get-transaction-name
 describe 'getTransactionName', ->
   it 'is a function', ->
     assert.isFunction getTransactionName
+
+  it 'joins all parts of the origin object', ->
+    name = getTransactionName(
+      origin:
+        apiName: 'a'
+        resourceGroupName: 'b'
+        resourceName: 'c'
+        actionName: 'd'
+        exampleName: 'e'
+    )
+    assert.equal(name, 'a > b > c > d > e')
+
+  it 'joins just the parts of the origin object, which are available', ->
+    name = getTransactionName(
+      origin:
+        apiName: null
+        resourceGroupName: 'a'
+        resourceName: undefined
+        actionName: 'b'
+        exampleName: ''
+    )
+    assert.equal(name, 'a > b')
+
+  it 'does not mind if any part of the origin object already contains the separator', ->
+    name = getTransactionName(
+      origin:
+        apiName: 'a'
+        resourceGroupName: 'b'
+        resourceName: 'c'
+        actionName: 'd'
+        exampleName: 'e > f'
+    )
+    assert.equal(name, 'a > b > c > d > e > f')

--- a/test/unit/transaction-name/get-transaction-name-test.coffee
+++ b/test/unit/transaction-name/get-transaction-name-test.coffee
@@ -1,12 +1,13 @@
-{assert} = require 'chai'
+{assert} = require('chai')
 
-getTransactionName = require '../../../src/transaction-name/get-transaction-name'
+getTransactionName = require('../../../src/transaction-name/get-transaction-name')
 
-describe 'getTransactionName', ->
-  it 'is a function', ->
-    assert.isFunction getTransactionName
 
-  it 'joins all parts of the origin object', ->
+describe('getTransactionName', ->
+  it('is a function', ->
+    assert.isFunction(getTransactionName)
+  )
+  it('joins all parts of the origin object', ->
     name = getTransactionName(
       origin:
         apiName: 'a'
@@ -16,8 +17,8 @@ describe 'getTransactionName', ->
         exampleName: 'e'
     )
     assert.equal(name, 'a > b > c > d > e')
-
-  it 'joins just the parts of the origin object, which are available', ->
+  )
+  it('joins just the parts of the origin object, which are available', ->
     name = getTransactionName(
       origin:
         apiName: null
@@ -27,8 +28,19 @@ describe 'getTransactionName', ->
         exampleName: ''
     )
     assert.equal(name, 'a > b')
-
-  it 'does not mind if any part of the origin object already contains the separator', ->
+  )
+  it('returns no separators if the origin object contains just one part', ->
+    name = getTransactionName(
+      origin:
+        apiName: null
+        resourceGroupName: 'a'
+        resourceName: undefined
+        actionName: ''
+        exampleName: ''
+    )
+    assert.equal(name, 'a')
+  )
+  it('does not mind if any part of the origin object already contains the separator', ->
     name = getTransactionName(
       origin:
         apiName: 'a'
@@ -38,3 +50,5 @@ describe 'getTransactionName', ->
         exampleName: 'e > f'
     )
     assert.equal(name, 'a > b > c > d > e > f')
+  )
+)


### PR DESCRIPTION
**BREAKING CHANGE**

This PR addresses https://github.com/apiaryio/dredd/issues/558

### Background

Dredd uses so called _transaction names_ (the `API Name > Group Name > ... > ...` string) to address particular transactions from API description. User can write hooks, which listen on these transaction names, and modify Dredd's behavior.

Currently, transaction names have many problems and limitations and we want to move away from them (see https://github.com/apiaryio/dredd/issues/227), but that's a long run. One of the limitations is that it doesn't take into account individual requests, content types, and status codes, which makes some combinations of requests-responses impossible to address in hooks. That's a fact we live with, at the moment.

When we were adding Swagger support to Dredd, I sticked to current Dredd capabilities when designing transaction names for Swagger, so the resulting implementation has the same flaws. However, in real world use, these limitations proved to be far more damaging for Swagger users, because Swagger basically just provides the URI and HTTP method and there are many duplicate transaction names as a result.

### Solution

We decided to make a step forward https://github.com/apiaryio/dredd/issues/227 and to add status code and content type as part of transaction names generated for Swagger documents. This change is attached to the existing code by duct tape and leverages `exampleName` to inject the information (it was previously unused for Swagger documents). This should be treated as known increase of technical debt and should be removed once Dredd fully migrates to https://github.com/apiaryio/dredd/issues/227 in the future. Meanwhile, this change radically improves Swagger users lives.

### Breaking Change

All Swagger users of Dredd hooks will have to change how they address transactions - e.g. `/112 > GET` will have to be changed to `/112 > GET > 200 > application/json`, etc. That's why this change is breaking. The breaking change status will be propagated also to Dredd project itself once upgrading Dredd Transactions in its `package.json`.