### PR TITLE
Add AppVeyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,14 @@ cache:
   directories:
     - "node_modules"
 before_install:
+  # Travis CI has only shallow clone of the repository. We need to get the 'master' branch
+  # so 'conventional-changelog-lint' could compare commits and lint them: marionebl/conventional-changelog-lint#7
+  - "git remote set-branches origin master && git fetch && git checkout master && git checkout -"
   - "npm -g install npm@latest"
-  - "curl -Lo travis_after_all.py https://raw.githubusercontent.com/dmakhno/travis_after_all/master/travis_after_all.py"
-before_script:
-  - "npm run lint"
+install: "npm install --no-optional"
 script:
+  - "if [[ $TRAVIS_NODE_VERSION = 6 ]]; then npm run lint; fi"  # 'conventional-changelog-lint' doesn't work with old Node.js versions
   - "npm test"
-after_success:  # travis_after_all.py is needed due to travis-ci/travis-ci#1548 & travis-ci/travis-ci#929
+after_success:
   - "npm run coveralls"
-  - "python travis_after_all.py"
-  - "export $(cat .to_export_back)"
   - "npm run semantic-release || true"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![npm version](https://badge.fury.io/js/dredd-transactions.svg)](https://badge.fury.io/js/dredd-transactions)
 [![Build Status](https://travis-ci.org/apiaryio/dredd-transactions.svg?branch=master)](https://travis-ci.org/apiaryio/dredd-transactions)
+[![Build status](https://ci.appveyor.com/api/projects/status/hh8l50ssai3p4d3f/branch/master?svg=true)](https://ci.appveyor.com/project/Apiary/dredd-transactions/branch/master)
 [![Dependencies Status](https://david-dm.org/apiaryio/dredd-transactions.svg)](https://david-dm.org/apiaryio/dredd-transactions)
 [![devDependencies Status](https://david-dm.org/apiaryio/dredd-transactions/dev-status.svg)](https://david-dm.org/apiaryio/dredd-transactions#info=devDependencies)
 [![Coverage Status](https://coveralls.io/repos/github/apiaryio/dredd-transactions/badge.svg?branch=master)](https://coveralls.io/github/apiaryio/dredd-transactions?branch=master)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,15 @@
+environment:
+  nodejs_version: "6"
+install:
+  - ps: Install-Product node 6
+  - "npm -g install npm@latest"
+  - "set PATH=%APPDATA%\\npm;%PATH%"
+  - "npm install --no-optional"
+cache:
+  - "node_modules"
+  - "%APPDATA%\\npm-cache"
+build: off
+test_script:
+  - "node --version"
+  - "npm --version"
+  - "npm test"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "coffee-coverage": "^1.0.1",
     "coffee-script": "^1.10.0",
     "coffeelint": "^1.15.7",
+    "conventional-changelog-lint": "^1.1.0",
     "coveralls": "^2.11.11",
     "cz-conventional-changelog": "^1.1.6",
     "drafter": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -4,12 +4,11 @@
   "description": "Compiles HTTP Transactions (Request-Response pairs) from API description document",
   "main": "lib/dredd-transactions.js",
   "scripts": {
-    "lint": "coffeelint ./src",
+    "lint": "coffeelint src",
     "build": "coffee -b -c -o lib/ src/",
-    "test": "./scripts/test",
-    "test:bdd": "./scripts/test -w",
+    "test": "mocha \"test/**/*-test.coffee\"",
     "prepublish": "npm run build",
-    "coveralls": "./scripts/cov mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+    "coveralls": "scripts/cov mocha-lcov-reporter | node_modules/coveralls/bin/coveralls.js",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Compiles HTTP Transactions (Request-Response pairs) from API description document",
   "main": "lib/dredd-transactions.js",
   "scripts": {
-    "lint": "coffeelint src",
+    "lint": "conventional-changelog-lint --from=master && coffeelint src",
     "build": "coffee -b -c -o lib/ src/",
     "test": "mocha \"test/**/*-test.coffee\"",
     "prepublish": "npm run build",
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "caseless": "^0.11.0",
-    "clone": "^1.0.2",
+    "clone": "^2.1.0",
     "deckardcain": "^0.3.2",
     "fury": "^2.1.0",
     "fury-adapter-apib-parser": "^0.3.0",
@@ -39,7 +39,7 @@
     "mocha": "^3.0.2",
     "mocha-lcov-reporter": "^1.2.0",
     "proxyquire": "^1.7.10",
-    "semantic-release": "^4.3.5",
+    "semantic-release": "^6.3.2",
     "sinon": "^1.17.4",
     "swagger-zoo": "^2.1.6",
     "tv4": "^1.2.7"


### PR DESCRIPTION
Adds AppVeyor and updates several dependencies. Updating `semantic-release` to the latest version removes the necessity for `travis_after_all.py`.