### PR TITLE
Drop support for Node 0.10 and 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 sudo: false
 language: "node_js"
 node_js:
-  - "0.10"
-  - "0.12"
   - "4"
   - "6"
 env:
@@ -19,7 +17,7 @@ before_install:
   - "npm -g install npm@latest"
 install: "npm install --no-optional"
 script:
-  - "if [[ $TRAVIS_NODE_VERSION = 6 ]]; then npm run lint; fi"  # 'conventional-changelog-lint' doesn't work with old Node.js versions
+  - "npm run lint"
   - "npm test"
 after_success:
   - "npm run coveralls"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.0-semantically-released",
   "description": "Compiles HTTP Transactions (Request-Response pairs) from API description document",
   "main": "lib/dredd-transactions.js",
+  "engines": {
+    "node": ">= 4"
+  },
   "scripts": {
     "lint": "conventional-changelog-lint --from=master && coffeelint src",
     "build": "coffee -b -c -o lib/ src/",


### PR DESCRIPTION
Related to https://github.com/apiaryio/dredd/issues/660

**BREAKING CHANGE:** Node 0.10 and 0.12 are not supported anymore. See https://github.com/nodejs/LTS#lts-schedule for details. Node.js 0.10 and 0.12 are both officially dead since 2016-12-31.