### PR TITLE
Empty strings as valid values for URI parameters

### DIFF
--- a/src/expand-uri-template-with-parameters.coffee
+++ b/src/expand-uri-template-with-parameters.coffee
@@ -41,9 +41,9 @@ expandUriTemplateWithParameters = (uriTemplate, parameters) ->
       for uriParameter in uriParameters
         param = parameters[uriParameter]
 
-        if param.example
+        if param.example? and param.example isnt ''
           toExpand[uriParameter] = param.example
-        else if param.default
+        else if param.default? and param.default isnt ''
           toExpand[uriParameter] = param.default
         else
           if param.required
@@ -54,7 +54,7 @@ expandUriTemplateWithParameters = (uriTemplate, parameters) ->
               document: #{uriParameter}\
             """)
 
-        if param.required and param.default
+        if param.required and param.default? and param.default isnt ''
           result.warnings.push("""\
             Required URI parameter '#{uriParameter}' has a default value.
             Default value for a required parameter doesn't make sense from \

--- a/src/expand-uri-template-with-parameters.coffee
+++ b/src/expand-uri-template-with-parameters.coffee
@@ -41,9 +41,9 @@ expandUriTemplateWithParameters = (uriTemplate, parameters) ->
       for uriParameter in uriParameters
         param = parameters[uriParameter]
 
-        if param.example? and param.example isnt ''
+        if param.example?
           toExpand[uriParameter] = param.example
-        else if param.default? and param.default isnt ''
+        else if param.default?
           toExpand[uriParameter] = param.default
         else
           if param.required
@@ -54,7 +54,7 @@ expandUriTemplateWithParameters = (uriTemplate, parameters) ->
               document: #{uriParameter}\
             """)
 
-        if param.required and param.default? and param.default isnt ''
+        if param.required and param.default?
           result.warnings.push("""\
             Required URI parameter '#{uriParameter}' has a default value.
             Default value for a required parameter doesn't make sense from \

--- a/src/validate-parameters.coffee
+++ b/src/validate-parameters.coffee
@@ -3,7 +3,7 @@ validateParameters = (params) ->
   result = {warnings: [], errors: []}
 
   for paramName, param of params
-    if param.required and not param.example and not param.default
+    if param.required and (not param.example? or param.example is '') and (not param.default? or param.default is '')
       text = "Required URI parameter '#{paramName}' has no example or default value."
       result.errors.push(text)
 

--- a/src/validate-parameters.coffee
+++ b/src/validate-parameters.coffee
@@ -3,18 +3,24 @@ validateParameters = (params) ->
   result = {warnings: [], errors: []}
 
   for paramName, param of params
-    if param.required and (not param.example? or param.example is '') and (not param.default? or param.default is '')
+    if param.required and not (param.example? or param.default?)
       text = "Required URI parameter '#{paramName}' has no example or default value."
       result.errors.push(text)
 
     switch param.type
       when 'number'
-        if isNaN(parseFloat(param.example))
-          text = "URI parameter '#{paramName}' is declared as 'number' but it is a string."
+        if param.example? and isNaN(parseFloat(param.example))
+          text = "URI parameter '#{paramName}' is declared as 'number' but its example value '#{param.example}' is not."
+          result.errors.push(text)
+        if param.default? and isNaN(parseFloat(param.default))
+          text = "URI parameter '#{paramName}' is declared as 'number' but its default value '#{param.example}' is not."
           result.errors.push(text)
       when 'boolean'
-        if param.example isnt 'true' and param.example isnt 'false'
-          text = "URI parameter '#{paramName}' is declared as 'boolean' but it is not."
+        if param.example? and param.example isnt 'true' and param.example isnt 'false'
+          text = "URI parameter '#{paramName}' is declared as 'boolean' but its example value '#{param.example}' is not."
+          result.errors.push(text)
+        if param.default? and param.default isnt 'true' and param.default isnt 'false'
+          text = "URI parameter '#{paramName}' is declared as 'boolean' but its default value '#{param.example}' is not."
           result.errors.push(text)
 
     if param.values.length > 0

--- a/test/fixtures/api-blueprint/default-required-boolean.apib
+++ b/test/fixtures/api-blueprint/default-required-boolean.apib
@@ -1,0 +1,12 @@
+FORMAT: 1A
+
+# Beehive API
+
+## Honey [/honey{?exampleBool}]
+
+### Get [GET]
+
++ Parameters
+    + exampleBool: `false` (required, boolean)
+
++ Response 200

--- a/test/fixtures/index.coffee
+++ b/test/fixtures/index.coffee
@@ -119,6 +119,10 @@ fixtures =
     apiBlueprint: fromFile('./api-blueprint/example-parameter.apib')
     swagger: fromFile('./swagger/example-parameter.yml')
   )
+  defaultRequiredBoolean: fixture(
+    apiBlueprint: fromFile('./api-blueprint/default-required-boolean.apib')
+    swagger: fromFile('./swagger/default-required-boolean.yml')
+  )
 
   # Specific to API Blueprint
   unrecognizable: fixture(

--- a/test/fixtures/swagger/default-required-boolean.yml
+++ b/test/fixtures/swagger/default-required-boolean.yml
@@ -1,0 +1,40 @@
+swagger: "2.0"
+info:
+  version: "1.0"
+  title: Beehive API
+  description: A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification
+host: petstore.swagger.io
+basePath: /
+schemes:
+  - http
+consumes:
+  - application/json
+produces:
+  - application/json
+paths:
+  /honey:
+    get:
+      parameters:
+        - name: exampleBool
+          in: query
+          type: boolean
+          required: true
+          default: 'false'
+      responses:
+        200:
+          description: Sample description
+          schema:
+            $ref: '#/definitions/Pet'
+definitions:
+  Pet:
+    required:
+      - id
+      - name
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+      tag:
+        type: string

--- a/test/integration/compile-test.coffee
+++ b/test/integration/compile-test.coffee
@@ -505,4 +505,23 @@ describe('compile() · all API description formats', ->
       )
     )
   )
+
+  describe('with example boolean value of URI parameter', ->
+    transaction = undefined
+    errors = undefined
+
+    fixtures.defaultRequiredBoolean.forEachDescribe(({source}) ->
+      beforeEach((done) ->
+        compileFixture(source, (args...) ->
+          [err, compilationResult] = args
+          transaction = compilationResult.transactions[0]
+          done(err)
+        )
+      )
+      it('expands the request URI with the example value', ->
+        assert.equal(transaction.request.uri, '/honey?exampleBool=false')
+      )
+    )
+  )
+
 )

--- a/test/unit/expand-uri-template-with-parameters-test.coffee
+++ b/test/unit/expand-uri-template-with-parameters-test.coffee
@@ -355,3 +355,48 @@ describe 'expandUriTemplateWithParameters', ->
 
           it 'should return some URI', ->
             assert.isNotNull data['uri']
+
+
+        describe 'when example value are not given', ->
+          before ->
+            uriTemplate = '/machines/{name}'
+            parameters =
+              name:
+                description: 'Machine name'
+                type: 'boolean'
+                required: true
+                default: false
+                example: ''
+
+            data = expandUriTemplateWithParameters uriTemplate, parameters
+
+          it 'should return no error', ->
+            assert.equal data['errors'].length, 0
+
+          it 'should return 1 warning', ->
+            assert.equal data['warnings'].length, 1
+
+          it 'should return some URI', ->
+            assert.isNotNull data['uri']
+
+        describe 'when default values are not given', ->
+          before ->
+            uriTemplate = '/machines/{name}'
+            parameters =
+              name:
+                description: 'Machine name'
+                type: 'boolean'
+                required: true
+                default: ''
+                example: false
+
+            data = expandUriTemplateWithParameters uriTemplate, parameters
+
+          it 'should return no error', ->
+            assert.equal data['errors'].length, 0
+
+          it 'should return no warning', ->
+            assert.equal data['warnings'].length, 0
+
+          it 'should return some URI', ->
+            assert.isNotNull data['uri']

--- a/test/unit/expand-uri-template-with-parameters-test.coffee
+++ b/test/unit/expand-uri-template-with-parameters-test.coffee
@@ -15,14 +15,14 @@ describe 'expandUriTemplateWithParameters', ->
         type: 'string'
         required: true
         example: 'waldo'
-        default: ''
+        default: null
 
     data = expandUriTemplateWithParameters uriTemplate, parameters
 
   it 'should return an object', ->
     assert.isObject data
 
-  describe 'returned obejct', ->
+  describe 'returned object', ->
     [
       'errors'
       'warnings'
@@ -40,7 +40,7 @@ describe 'expandUriTemplateWithParameters', ->
             type: 'string'
             required: true
             example: 'waldo'
-            default: ''
+            default: null
 
         data = expandUriTemplateWithParameters uriTemplate, parameters
 
@@ -74,7 +74,7 @@ describe 'expandUriTemplateWithParameters', ->
               type: 'string'
               required: true
               example: 'waldo'
-              default: ''
+              default: null
 
           data = expandUriTemplateWithParameters uriTemplate, parameters
 
@@ -124,14 +124,14 @@ describe 'expandUriTemplateWithParameters', ->
               type: 'string'
               required: true
               example: 'waldo'
-              default: ''
+              default: null
             fanny:
               required: false
               description: 'Machine fanny'
               type: 'string'
               required: true
               example: 'wild'
-              default: ''
+              default: null
 
           data = expandUriTemplateWithParameters uriTemplate, parameters
 
@@ -155,8 +155,8 @@ describe 'expandUriTemplateWithParameters', ->
                 description: 'Machine name'
                 type: 'string'
                 required: true
-                example: ''
-                default: ''
+                example: null
+                default: null
 
             data = expandUriTemplateWithParameters uriTemplate, parameters
 
@@ -187,7 +187,32 @@ describe 'expandUriTemplateWithParameters', ->
                 type: 'string'
                 required: true
                 example: 'example-one'
-                default: ''
+                default: null
+
+            data = expandUriTemplateWithParameters uriTemplate, parameters
+
+          it 'should return no error', ->
+            assert.equal data['errors'].length, 0
+
+          it 'should return no warning', ->
+            assert.equal data['warnings'].length, 0
+
+          it 'should use example value to URI parameter expansion', ->
+            assert.include data['uri'], parameters['name']['example']
+
+          it 'should return URI', ->
+            assert.isNotNull data['uri']
+
+        describe 'when example value is given as empty string', ->
+          before ->
+            uriTemplate = '/machines/{name}'
+            parameters =
+              name:
+                description: 'Machine name'
+                type: 'string'
+                required: true
+                example: ''
+                default: null
 
             data = expandUriTemplateWithParameters uriTemplate, parameters
 
@@ -211,7 +236,7 @@ describe 'expandUriTemplateWithParameters', ->
                 description: 'Machine name'
                 type: 'string'
                 required: true
-                example: ''
+                example: null
                 default: 'example-one'
 
             data = expandUriTemplateWithParameters uriTemplate, parameters
@@ -221,6 +246,31 @@ describe 'expandUriTemplateWithParameters', ->
 
           it 'should return one warning', ->
             assert.equal data['warnings'].length, 1
+
+          it 'should return warning about pointlessness of default value of a required parameter', ->
+            assert.include data.warnings[0], 'Default value for a required parameter'
+
+          it 'should use default value to URI parameter expansion', ->
+            assert.include data['uri'], parameters['name']['default']
+
+          it 'should return URI', ->
+            assert.isNotNull data['uri']
+
+        describe 'when default value is given as empty string', ->
+          before ->
+            uriTemplate = '/machines/{name}'
+            parameters =
+              name:
+                description: 'Machine name'
+                type: 'string'
+                required: true
+                example: null
+                default: ''
+
+            data = expandUriTemplateWithParameters uriTemplate, parameters
+
+          it 'should return no error', ->
+            assert.equal data['errors'].length, 0
 
           it 'should return warning about pointlessness of default value of a required parameter', ->
             assert.include data.warnings[0], 'Default value for a required parameter'
@@ -259,6 +309,34 @@ describe 'expandUriTemplateWithParameters', ->
           it 'should return URI', ->
             assert.isNotNull data['uri']
 
+      describe 'when example is given as empty string and default is given as non-empty string', ->
+          before ->
+            uriTemplate = '/machines/{name}'
+            parameters =
+              name:
+                description: 'Machine name'
+                type: 'string'
+                required: true
+                example: ''
+                default: 'default-one'
+
+            data = expandUriTemplateWithParameters uriTemplate, parameters
+
+          it 'should return no error', ->
+            assert.equal data['errors'].length, 0
+
+          it 'should return one warning', ->
+            assert.equal data['warnings'].length, 1
+
+          it 'should return warning about pointlessness of default value of a required parameter', ->
+            assert.include data.warnings[0], 'Default value for a required parameter'
+
+          it 'should use example value to URI parameter expansion', ->
+            assert.include data['uri'], parameters['name']['example']
+
+          it 'should return URI', ->
+            assert.isNotNull data['uri']
+
       describe 'when expression parameter is optional', ->
         before ->
           uriTemplate = '/machines/{name}'
@@ -268,7 +346,7 @@ describe 'expandUriTemplateWithParameters', ->
               type: 'string'
               required: false
               example: 'example-one'
-              default: ''
+              default: null
 
           data = expandUriTemplateWithParameters uriTemplate, parameters
 
@@ -293,7 +371,7 @@ describe 'expandUriTemplateWithParameters', ->
                 type: 'string'
                 required: false
                 default: 'default-one'
-                example: ''
+                example: null
 
             data = expandUriTemplateWithParameters uriTemplate, parameters
 
@@ -305,6 +383,31 @@ describe 'expandUriTemplateWithParameters', ->
 
           it 'should use default value to URI parameter expansion', ->
             assert.include data['uri'], parameters['name']['default']
+
+          it 'should return URI', ->
+            assert.isNotNull data['uri']
+
+        describe 'when default value is given and example is empty string', ->
+          before ->
+            uriTemplate = '/machines/{name}'
+            parameters =
+              name:
+                description: 'Machine name'
+                type: 'string'
+                required: false
+                default: 'default-one'
+                example: ''
+
+            data = expandUriTemplateWithParameters uriTemplate, parameters
+
+          it 'should return no error', ->
+            assert.equal data['errors'].length, 0
+
+          it 'should return no warning', ->
+            assert.equal data['warnings'].length, 0
+
+          it 'should use example value to URI parameter expansion', ->
+            assert.include data['uri'], parameters['name']['example']
 
           it 'should return URI', ->
             assert.isNotNull data['uri']
@@ -342,8 +445,8 @@ describe 'expandUriTemplateWithParameters', ->
                 description: 'Machine name'
                 type: 'string'
                 required: false
-                default: ''
-                example: ''
+                default: null
+                example: null
 
             data = expandUriTemplateWithParameters uriTemplate, parameters
 
@@ -357,7 +460,7 @@ describe 'expandUriTemplateWithParameters', ->
             assert.isNotNull data['uri']
 
 
-        describe 'when example value are not given', ->
+        describe 'when boolean example value is not given', ->
           before ->
             uriTemplate = '/machines/{name}'
             parameters =
@@ -366,7 +469,7 @@ describe 'expandUriTemplateWithParameters', ->
                 type: 'boolean'
                 required: true
                 default: false
-                example: ''
+                example: null
 
             data = expandUriTemplateWithParameters uriTemplate, parameters
 
@@ -379,7 +482,7 @@ describe 'expandUriTemplateWithParameters', ->
           it 'should return some URI', ->
             assert.isNotNull data['uri']
 
-        describe 'when default values are not given', ->
+        describe 'when boolean default value is not given', ->
           before ->
             uriTemplate = '/machines/{name}'
             parameters =
@@ -387,7 +490,7 @@ describe 'expandUriTemplateWithParameters', ->
                 description: 'Machine name'
                 type: 'boolean'
                 required: true
-                default: ''
+                default: null
                 example: false
 
             data = expandUriTemplateWithParameters uriTemplate, parameters

--- a/test/unit/validate-parameters-test.coffee
+++ b/test/unit/validate-parameters-test.coffee
@@ -248,3 +248,31 @@ describe 'validateParameters', ->
         result = validateParameters params
         assert.equal result['errors'].length, 0
 
+
+    describe 'when type is boolean and example value is false', () ->
+      it 'should not set the error', () ->
+        params =
+          name:
+            description: 'Machine name'
+            type: 'boolean'
+            required: true
+            example: 'false'
+            default: ''
+            values: []
+
+        result = validateParameters params
+        assert.equal result['errors'].length, 0
+
+    describe 'when type is boolean and default value is parseable bool and example value is empty', () ->
+      it 'should not set the error', () ->
+        params =
+          name:
+            description: 'Machine name'
+            type: 'boolean'
+            required: true
+            example: ''
+            default: 'false'
+            values: []
+
+        result = validateParameters params
+        assert.equal result['errors'].length, 1

--- a/test/unit/validate-parameters-test.coffee
+++ b/test/unit/validate-parameters-test.coffee
@@ -25,7 +25,7 @@ describe 'validateParameters', ->
           type: 'string'
           required: true
           example: '1.1'
-          default: ''
+          default: null
           values: []
 
       result = validateParameters params
@@ -42,7 +42,7 @@ describe 'validateParameters', ->
           type: 'string'
           required: true
           example: '6f7c1245'
-          default: ''
+          default: null
           values: []
 
       result = validateParameters params
@@ -55,7 +55,7 @@ describe 'validateParameters', ->
           type: 'string'
           required: true
           example: 'waldo'
-          default: ''
+          default: null
           values: []
 
       result = validateParameters params
@@ -69,7 +69,7 @@ describe 'validateParameters', ->
           type: 'number'
           required: true
           example: 'waldo'
-          default: ''
+          default: null
           values: []
 
       result = validateParameters params
@@ -85,7 +85,7 @@ describe 'validateParameters', ->
           type: 'number'
           required: true
           example: '1.1'
-          default: ''
+          default: null
           values: []
 
       result = validateParameters params
@@ -99,7 +99,7 @@ describe 'validateParameters', ->
           type: 'string'
           required: true
           example: 'D'
-          default: ''
+          default: null
           values: [
             { "value": "A" },
             { "value": "B" },
@@ -119,7 +119,7 @@ describe 'validateParameters', ->
           type: 'string'
           required: true
           example: 'A'
-          default: ''
+          default: null
           values: [
             { "value": "A" },
             { "value": "B" },
@@ -137,7 +137,7 @@ describe 'validateParameters', ->
           type: 'boolean'
           required: true
           example: 'booboo'
-          default: ''
+          default: null
           values: []
 
       result = validateParameters params
@@ -153,15 +153,15 @@ describe 'validateParameters', ->
           type: 'boolean'
           required: true
           example: 'true'
-          default: ''
+          default: null
           values: []
 
       result = validateParameters params
       assert.equal result['errors'].length, 0
 
   describe 'when parameter is required', () ->
-    describe 'and example and default value are empty', () ->
-      it 'should set descirptive error', () ->
+    describe 'and example and default value are empty strings', () ->
+      it 'should not set the error', () ->
         params =
           name:
             description: 'Machine name'
@@ -169,6 +169,64 @@ describe 'validateParameters', ->
             required: true
             example: ''
             default: ''
+            values: []
+
+        result = validateParameters params
+        assert.equal result['errors'].length, 0
+
+    describe 'and example is empty string and default value is null', () ->
+      it 'should not set the error', () ->
+        params =
+          name:
+            description: 'Machine name'
+            type: 'string'
+            required: true
+            example: ''
+            default: null
+            values: []
+
+        result = validateParameters params
+        assert.equal result['errors'].length, 0
+
+    describe 'and example is null and default value is empty string', () ->
+      it 'should not set the error', () ->
+        params =
+          name:
+            description: 'Machine name'
+            type: 'string'
+            required: true
+            example: null
+            default: ''
+            values: []
+
+        result = validateParameters params
+        assert.equal result['errors'].length, 0
+
+    describe 'and example and default value are null', () ->
+      it 'should set descirptive error', () ->
+        params =
+          name:
+            description: 'Machine name'
+            type: 'string'
+            required: true
+            example: null
+            default: null
+            values: []
+
+        result = validateParameters params
+        message = result['errors'][0]
+        assert.include message, 'name'
+        assert.include message, 'Required'
+
+    describe 'and example and default value are undefined', () ->
+      it 'should set descirptive error', () ->
+        params =
+          name:
+            description: 'Machine name'
+            type: 'string'
+            required: true
+            example: undefined
+            default: undefined
             values: []
 
         result = validateParameters params
@@ -183,7 +241,7 @@ describe 'validateParameters', ->
             description: 'Machine name'
             type: 'string'
             required: true
-            example: ''
+            example: null
             default: 'bagaboo'
             values: []
 
@@ -198,7 +256,7 @@ describe 'validateParameters', ->
             type: 'string'
             required: true
             example: 'booboo'
-            default: ''
+            default: null
             values: []
 
         result = validateParameters params
@@ -206,14 +264,14 @@ describe 'validateParameters', ->
 
   describe 'when parameter is not required', () ->
     describe 'and example and default value are empty', () ->
-      it 'should not set descirptive error', ->
+      it 'should not set the error', ->
         params =
           name:
             description: 'Machine name'
             type: 'string'
             required: false
-            example: ''
-            default: ''
+            example: null
+            default: null
             values: []
 
         result = validateParameters params
@@ -227,7 +285,7 @@ describe 'validateParameters', ->
             description: 'Machine name'
             type: 'string'
             required: true
-            example: ''
+            example: null
             default: 'bagaboo'
             values: []
 
@@ -242,7 +300,7 @@ describe 'validateParameters', ->
             type: 'string'
             required: true
             example: 'booboo'
-            default: ''
+            default: null
             values: []
 
         result = validateParameters params
@@ -257,14 +315,14 @@ describe 'validateParameters', ->
             type: 'boolean'
             required: true
             example: 'false'
-            default: ''
+            default: null
             values: []
 
         result = validateParameters params
         assert.equal result['errors'].length, 0
 
-    describe 'when type is boolean and default value is parseable bool and example value is empty', () ->
-      it 'should not set the error', () ->
+    describe 'when type is boolean and default value is parseable bool and example value is empty string', () ->
+      it 'should set descirptive error', () ->
         params =
           name:
             description: 'Machine name'
@@ -275,4 +333,36 @@ describe 'validateParameters', ->
             values: []
 
         result = validateParameters params
-        assert.equal result['errors'].length, 1
+        message = result['errors'][0]
+        assert.include message, 'name'
+        assert.include message, 'boolean'
+
+    describe 'when type is boolean and default value is parseable bool and example value is empty', () ->
+      it 'should not set the error', () ->
+        params =
+          name:
+            description: 'Machine name'
+            type: 'boolean'
+            required: true
+            example: null
+            default: 'false'
+            values: []
+
+        result = validateParameters params
+        assert.equal result['errors'].length, 0
+
+    describe 'when type is boolean and default value is not parseable bool and example value is empty', () ->
+      it 'should not set the error', () ->
+        params =
+          name:
+            description: 'Machine name'
+            type: 'boolean'
+            required: true
+            example: null
+            default: 'booooo'
+            values: []
+
+        result = validateParameters params
+        message = result['errors'][0]
+        assert.include message, 'name'
+        assert.include message, 'boolean'


### PR DESCRIPTION
⚠️ Work in progress. Do not merge.

------

This is my attempt to finish the work started in https://github.com/apiaryio/dredd-transactions/pull/71/ by @motoyasu-saburi and described in https://github.com/apiaryio/dredd/issues/677 and #70. It turns out this is much larger problem then anticipated. It is a breaking change in how Dredd works and it has many corner cases:

- required/optional
- default/example
- null/undefined/empty string
- query/path parameters

Regarding the last point, e.g. we do not want `/sth/{param}/sth` to work with empty strings, but we do want `/sth{?param}` to work with empty strings. I suggest we clearly specify all the corner cases (similar to https://github.com/apiaryio/dredd-transactions/pull/71#pullrequestreview-24008494) first, then write _a lot_ of tests and then let's change the implementation and release the next major version of Dredd.

---------

@motoyasu-saburi Thank you very much for bringing the whole thing up. You did awesome load of work. No matter any delays, your contribution in the issues and in the PR you started was a great help in understanding the whole problem and will be eternally carved in the history of Dredd development 🙇 