### PR TITLE
Use API Elements as parser output

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,10 @@
     "caseless": "^0.12.0",
     "clone": "^2.1.1",
     "deckardcain": "^0.3.2",
-    "fury": "3.0.0-beta.2",
-    "fury-adapter-apib-parser": "0.7.0",
-    "fury-adapter-swagger": "0.12.0-beta.3",
+    "fury": "3.0.0-beta.3",
+    "fury-adapter-apib-parser": "0.8.0",
+    "fury-adapter-swagger": "0.12.0",
+    "minim": "0.18.0",
     "sift": "^3.3.10",
     "traverse": "^0.6.6",
     "uri-template": "^1.0.0"

--- a/src/api-elements-to-json.coffee
+++ b/src/api-elements-to-json.coffee
@@ -1,0 +1,10 @@
+fury = require('fury')
+JSON06Serialiser = require('minim/lib/serialisers/json-0.6')
+
+
+# This file should be replaced with fury.minim.toRefract(apiElements) once
+# all dredd-transactions use minim.
+
+
+module.exports = (result) ->
+  new JSON06Serialiser(fury.minim).serialise(result)

--- a/src/compile.coffee
+++ b/src/compile.coffee
@@ -1,4 +1,3 @@
-
 clone = require('clone')
 caseless = require('caseless')
 
@@ -6,9 +5,12 @@ caseless = require('caseless')
 validateParameters = require('./validate-parameters')
 detectTransactionExamples = require('./detect-transaction-examples')
 expandUriTemplateWithParameters = require('./expand-uri-template-with-parameters')
+apiElementsToJson = require('./api-elements-to-json')
 
 
-compile = (mediaType, parseResult, filename) ->
+compile = (mediaType, apiElements, filename) ->
+  parseResult = apiElementsToJson(apiElements)
+
   transactions = []
   errors = []
   warnings = []

--- a/test/integration/compile-api-blueprint-test.coffee
+++ b/test/integration/compile-api-blueprint-test.coffee
@@ -6,6 +6,7 @@ fixtures = require('../fixtures')
 createLocationSchema = require('../schemas/location')
 createOriginSchema = require('../schemas/origin')
 {assert, compileFixture} = require('../utils')
+apiElementsToJson = require('../../src/api-elements-to-json')
 
 
 describe('compile() · API Blueprint', ->
@@ -17,9 +18,10 @@ describe('compile() · API Blueprint', ->
     transactions = undefined
 
     beforeEach((done) ->
-      compileFixture(fixtures.missingTitleAnnotation.apiBlueprint, (args...) ->
-        [err, {warnings, transactions}] = args
-        done(err)
+      compileFixture(fixtures.missingTitleAnnotation.apiBlueprint, (err, results) ->
+        return done(err) if err
+        {warnings, transactions} = results
+        done()
       )
     )
 
@@ -56,9 +58,10 @@ describe('compile() · API Blueprint', ->
     transactions = undefined
 
     beforeEach((done) ->
-      compileFixture(fixtures.notSpecifiedInUriTemplateAnnotation.apiBlueprint, (args...) ->
-        [err, {warnings, transactions}] = args
-        done(err)
+      compileFixture(fixtures.notSpecifiedInUriTemplateAnnotation.apiBlueprint, (err, results) ->
+        return done(err) if err
+        {warnings, transactions} = results
+        done()
       )
     )
 
@@ -100,10 +103,10 @@ describe('compile() · API Blueprint', ->
     beforeEach((done) ->
       stubs = {'./detect-transaction-examples': detectTransactionExamples}
 
-      compileFixture(fixtures.multipleTransactionExamples.apiBlueprint, {stubs}, (args...) ->
-        [err, compilationResult] = args
-        transactions = compilationResult.transactions
-        done(err)
+      compileFixture(fixtures.multipleTransactionExamples.apiBlueprint, {stubs}, (err, results) ->
+        return done(err) if err
+        {transactions} = results
+        done()
       )
     )
 
@@ -141,15 +144,14 @@ describe('compile() · API Blueprint', ->
 
   describe('without multiple transaction examples', ->
     detectTransactionExamples = sinon.spy(require('../../src/detect-transaction-examples'))
-    compilationResult = undefined
-    transaction = undefined
+    transactions = undefined
 
     beforeEach((done) ->
       stubs = {'./detect-transaction-examples': detectTransactionExamples}
 
-      compileFixture(fixtures.oneTransactionExample.apiBlueprint, {stubs}, (args...) ->
-        [err, compilationResult] = args
-        transaction = compilationResult.transactions[0]
+      compileFixture(fixtures.oneTransactionExample.apiBlueprint, {stubs}, (err, results) ->
+        return done(err) if err
+        {transactions} = results
         done(err)
       )
     )
@@ -158,14 +160,14 @@ describe('compile() · API Blueprint', ->
       assert.isTrue(detectTransactionExamples.called)
     )
     it('is compiled into one transaction', ->
-      assert.equal(compilationResult.transactions.length, 1)
+      assert.equal(transactions.length, 1)
     )
     context('the transaction', ->
       it("is identified as part of no example in \'origin\'", ->
-        assert.equal(transaction.origin.exampleName, '')
+        assert.equal(transactions[0].origin.exampleName, '')
       )
       it("is identified as part of Example 1 in \'pathOrigin\'", ->
-        assert.equal(transaction.pathOrigin.exampleName, 'Example 1')
+        assert.equal(transactions[0].pathOrigin.exampleName, 'Example 1')
       )
     )
   )
@@ -176,10 +178,10 @@ describe('compile() · API Blueprint', ->
     filename = 'apiDescription.apib'
 
     beforeEach((done) ->
-      compileFixture(fixtures.arbitraryAction.apiBlueprint, {filename}, (args...) ->
-        [err, compilationResult] = args
-        [transaction0, transaction1] = compilationResult.transactions
-        done(err)
+      compileFixture(fixtures.arbitraryAction.apiBlueprint, {filename}, (err, results) ->
+        return done(err) if err
+        [transaction0, transaction1] = results.transactions
+        done()
       )
     )
 
@@ -207,10 +209,10 @@ describe('compile() · API Blueprint', ->
     filename = 'apiDescription.apib'
 
     beforeEach((done) ->
-      compileFixture(fixtures.withoutSections.apiBlueprint, {filename}, (args...) ->
-        [err, compilationResult] = args
-        transaction = compilationResult.transactions[0]
-        done(err)
+      compileFixture(fixtures.withoutSections.apiBlueprint, {filename}, (err, results) ->
+        return done(err) if err
+        transaction = results.transactions[0]
+        done()
       )
     )
 
@@ -249,10 +251,10 @@ describe('compile() · API Blueprint', ->
     transaction = undefined
 
     beforeEach((done) ->
-      compileFixture(fixtures.preferSample.apiBlueprint, (args...) ->
-        [err, compilationResult] = args
-        transaction = compilationResult.transactions[0]
-        done(err)
+      compileFixture(fixtures.preferSample.apiBlueprint, (err, results) ->
+        return done(err) if err
+        transaction = results.transactions[0]
+        done()
       )
     )
 

--- a/test/unit/parse-test.coffee
+++ b/test/unit/parse-test.coffee
@@ -1,10 +1,10 @@
-
 sinon = require('sinon')
 fury = require('fury')
-{assert} = require('../utils')
 
+{assert} = require('../utils')
 fixtures = require('../fixtures')
 parse = require('../../src/parse')
+apiElementsToJson = require('../../src/api-elements-to-json')
 
 
 describe('Parsing API description document', ->
@@ -32,15 +32,16 @@ describe('Parsing API description document', ->
       it('produces media type', ->
         assert.match(mediaType, reMediaType)
       )
-      it('the parse result is in the API Elements format', ->
+      it('the parse result is API Elements represented by minim objects', ->
         assert.equal(apiElements.element, 'parseResult')
         assert.isArray(apiElements.content)
+        assert.isObject(apiElementsToJson(apiElements))
       )
       it('the parse result contains no annotation elements', ->
-        assert.notInclude(JSON.stringify(apiElements), '"annotation"')
+        assert.equal(apiElements.annotations?.length, 0)
       )
       it('the parse result contains source map elements', ->
-        assert.include(JSON.stringify(apiElements), '"sourceMap"')
+        assert.include(JSON.stringify(apiElementsToJson(apiElements)), '"sourceMap"')
       )
     )
   )
@@ -67,11 +68,11 @@ describe('Parsing API description document', ->
       it('produces media type', ->
         assert.match(mediaType, reMediaType)
       )
-      it('the parse result contains annotation element', ->
-        assert.include(JSON.stringify(apiElements), '"annotation"')
+      it('the parse result contains annotation elements', ->
+        assert.isAbove(apiElements.annotations?.length, 0)
       )
-      it('the annotation is an error', ->
-        assert.include(JSON.stringify(apiElements), '"error"')
+      it('the annotations are errors', ->
+        assert.equal(apiElements.errors?.length, apiElements.annotations.length)
       )
     )
   )
@@ -98,11 +99,11 @@ describe('Parsing API description document', ->
       it('produces media type', ->
         assert.match(mediaType, reMediaType)
       )
-      it('the parse result contains annotation element', ->
-        assert.include(JSON.stringify(apiElements), '"annotation"')
+      it('the parse result contains annotation elements', ->
+        assert.isAbove(apiElements.annotations?.length, 0)
       )
-      it('the annotation is a warning', ->
-        assert.include(JSON.stringify(apiElements), '"warning"')
+      it('the annotations are warnings', ->
+        assert.equal(apiElements.warnings?.length, apiElements.annotations.length)
       )
     )
   )
@@ -157,14 +158,14 @@ describe('Parsing API description document', ->
     it('produces media type', ->
       assert.match(mediaType, reMediaType)
     )
-    it('the parse result contains annotation element', ->
-      assert.include(JSON.stringify(apiElements), '"annotation"')
+    it('the parse result contains annotation elements', ->
+      assert.isAbove(apiElements.annotations?.length, 0)
     )
-    it('the annotation is a warning', ->
-      assert.include(JSON.stringify(apiElements), '"warning"')
+    it('the annotations are warnings', ->
+      assert.equal(apiElements.warnings?.length, apiElements.annotations.length)
     )
-    it('the warning is about falling back to API Blueprint', ->
-      assert.include(JSON.stringify(apiElements), 'to API Blueprint')
+    it('the first warning is about falling back to API Blueprint', ->
+      assert.include(apiElements.warnings.get(0).toValue(), 'to API Blueprint')
     )
   )
 
@@ -189,14 +190,14 @@ describe('Parsing API description document', ->
     it('produces media type', ->
       assert.match(mediaType, reMediaType)
     )
-    it('the parse result contains annotation element', ->
-      assert.include(JSON.stringify(apiElements), '"annotation"')
+    it('the parse result contains annotation elements', ->
+      assert.isAbove(apiElements.annotations?.length, 0)
     )
-    it('the annotation is a warning', ->
-      assert.include(JSON.stringify(apiElements), '"warning"')
+    it('the annotations are warnings', ->
+      assert.equal(apiElements.warnings?.length, apiElements.annotations.length)
     )
-    it('the warning is about falling back to API Blueprint', ->
-      assert.include(JSON.stringify(apiElements), 'to API Blueprint')
+    it('the first warning is about falling back to API Blueprint', ->
+      assert.include(apiElements.warnings.get(0).toValue(), 'to API Blueprint')
     )
   )
 )


### PR DESCRIPTION
This change allows to use minim in the compilation process.