### PR TITLE
Use API Elements as parser output

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
     "caseless": "^0.12.0",
     "clone": "^2.1.1",
     "deckardcain": "^0.3.2",
-    "fury": "^3.0.0-beta.3",
-    "fury-adapter-apib-parser": "^0.8.0",
-    "fury-adapter-swagger": "^0.12.0",
+    "fury": "3.0.0-beta.3",
+    "fury-adapter-apib-parser": "0.8.0",
+    "fury-adapter-swagger": "0.12.0",
     "sift": "^3.3.10",
     "traverse": "^0.6.6",
     "uri-template": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "fury": "3.0.0-beta.3",
     "fury-adapter-apib-parser": "0.8.0",
     "fury-adapter-swagger": "0.12.0",
+    "minim": "0.18.0",
     "sift": "^3.3.10",
     "traverse": "^0.6.6",
     "uri-template": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "uri-template": "^1.0.0"
   },
   "devDependencies": {
-    "chai": "^3.5.0",
+    "chai": "^4.1.0",
     "chai-json-schema": "^1.3.0",
     "coffee-coverage": "^2.0.1",
     "coffee-script": "^1.12.6",

--- a/src/api-elements-to-json.coffee
+++ b/src/api-elements-to-json.coffee
@@ -1,0 +1,10 @@
+fury = require('fury')
+JSON06Serialiser = require('minim/lib/serialisers/json-0.6')
+
+
+# This file should be replaced with fury.minim.toRefract(apiElements) once
+# all dredd-transactions use minim.
+
+
+module.exports = (result) ->
+  new JSON06Serialiser(fury.minim).serialise(result)

--- a/src/compile.coffee
+++ b/src/compile.coffee
@@ -6,9 +6,12 @@ caseless = require('caseless')
 validateParameters = require('./validate-parameters')
 detectTransactionExamples = require('./detect-transaction-examples')
 expandUriTemplateWithParameters = require('./expand-uri-template-with-parameters')
+apiElementsToJson = require('./api-elements-to-json')
 
 
-compile = (mediaType, parseResult, filename) ->
+compile = (mediaType, apiElements, filename) ->
+  parseResult = apiElementsToJson(apiElements)
+
   transactions = []
   errors = []
   warnings = []

--- a/src/parse.coffee
+++ b/src/parse.coffee
@@ -1,11 +1,10 @@
-
 deckardcain = require('deckardcain')
 fury = require('fury')
 fury.use(require('fury-adapter-apib-parser'))
 fury.use(require('fury-adapter-swagger'))
 
-JSON06Serialiser = require('minim/lib/serialisers/json-0.6')
-serialiser =  new JSON06Serialiser(fury.minim)
+apiElementsToJson = require('./api-elements-to-json')
+
 
 createAnnotation = (message, type) ->
   {
@@ -35,7 +34,7 @@ parse = (source, callback) ->
       err = new Error(err.message)
 
     if apiElements
-      apiElements = serialiser.serialise(apiElements)
+      apiElements = apiElementsToJson(apiElements)
       apiElements.content = apiElements.content.concat(annotations)
     else
       apiElements = null

--- a/src/parse.coffee
+++ b/src/parse.coffee
@@ -33,7 +33,6 @@ parse = (source, callback) ->
 
     if apiElements
       apiElements.unshift(warning) if warning
-      apiElements = apiElementsToJson(apiElements)
     else
       apiElements = null
 

--- a/src/parse.coffee
+++ b/src/parse.coffee
@@ -6,24 +6,22 @@ fury.use(require('fury-adapter-swagger'))
 apiElementsToJson = require('./api-elements-to-json')
 
 
-createAnnotation = (message, type) ->
-  {
-    element: 'annotation'
-    meta: {classes: [type]}
-    content: message
-  }
+createWarning = (message) ->
+  annotation = new fury.minim.elements.Annotation(message)
+  annotation.classes.push('warning')
+  return annotation
 
 
 parse = (source, callback) ->
-  annotations = []
+  warning = null
   mediaType = deckardcain.identify(source)
 
   unless mediaType
     mediaType = 'text/vnd.apiblueprint'
-    annotations.push(createAnnotation('''\
+    warning = createWarning('''\
       Could not recognize API description format. \
       Falling back to API Blueprint by default.\
-    ''', 'warning'))
+    ''')
 
   args = {source, mediaType, generateSourceMap: true}
   fury.parse(args, (err, apiElements) ->
@@ -34,8 +32,8 @@ parse = (source, callback) ->
       err = new Error(err.message)
 
     if apiElements
+      apiElements.unshift(warning) if warning
       apiElements = apiElementsToJson(apiElements)
-      apiElements.content = apiElements.content.concat(annotations)
     else
       apiElements = null
 

--- a/test/unit/parse-test.coffee
+++ b/test/unit/parse-test.coffee
@@ -1,10 +1,10 @@
-
 sinon = require('sinon')
 fury = require('fury')
-{assert} = require('../utils')
 
+{assert} = require('../utils')
 fixtures = require('../fixtures')
 parse = require('../../src/parse')
+apiElementsToJson = require('../../src/api-elements-to-json')
 
 
 describe('Parsing API description document', ->
@@ -32,15 +32,16 @@ describe('Parsing API description document', ->
       it('produces media type', ->
         assert.match(mediaType, reMediaType)
       )
-      it('the parse result is in the API Elements format', ->
+      it('the parse result is API Elements represented by minim objects', ->
         assert.equal(apiElements.element, 'parseResult')
         assert.isArray(apiElements.content)
+        assert.isObject(apiElementsToJson(apiElements))
       )
       it('the parse result contains no annotation elements', ->
-        assert.notInclude(JSON.stringify(apiElements), '"annotation"')
+        assert.equal(apiElements.annotations?.length, 0)
       )
       it('the parse result contains source map elements', ->
-        assert.include(JSON.stringify(apiElements), '"sourceMap"')
+        assert.include(JSON.stringify(apiElementsToJson(apiElements)), '"sourceMap"')
       )
     )
   )
@@ -67,11 +68,11 @@ describe('Parsing API description document', ->
       it('produces media type', ->
         assert.match(mediaType, reMediaType)
       )
-      it('the parse result contains annotation element', ->
-        assert.include(JSON.stringify(apiElements), '"annotation"')
+      it('the parse result contains annotation elements', ->
+        assert.isAbove(apiElements.annotations?.length, 0)
       )
-      it('the annotation is an error', ->
-        assert.include(JSON.stringify(apiElements), '"error"')
+      it('the annotations are errors', ->
+        assert.equal(apiElements.errors?.length, apiElements.annotations.length)
       )
     )
   )
@@ -98,11 +99,11 @@ describe('Parsing API description document', ->
       it('produces media type', ->
         assert.match(mediaType, reMediaType)
       )
-      it('the parse result contains annotation element', ->
-        assert.include(JSON.stringify(apiElements), '"annotation"')
+      it('the parse result contains annotation elements', ->
+        assert.isAbove(apiElements.annotations?.length, 0)
       )
-      it('the annotation is a warning', ->
-        assert.include(JSON.stringify(apiElements), '"warning"')
+      it('the annotations are warnings', ->
+        assert.equal(apiElements.warnings?.length, apiElements.annotations.length)
       )
     )
   )
@@ -157,14 +158,14 @@ describe('Parsing API description document', ->
     it('produces media type', ->
       assert.match(mediaType, reMediaType)
     )
-    it('the parse result contains annotation element', ->
-      assert.include(JSON.stringify(apiElements), '"annotation"')
+    it('the parse result contains annotation elements', ->
+      assert.isAbove(apiElements.annotations?.length, 0)
     )
-    it('the annotation is a warning', ->
-      assert.include(JSON.stringify(apiElements), '"warning"')
+    it('the annotations are warnings', ->
+      assert.equal(apiElements.warnings?.length, apiElements.annotations.length)
     )
-    it('the warning is about falling back to API Blueprint', ->
-      assert.include(JSON.stringify(apiElements), 'to API Blueprint')
+    it('the first warning is about falling back to API Blueprint', ->
+      assert.include(apiElements.warnings.get(0).toValue(), 'to API Blueprint')
     )
   )
 
@@ -189,14 +190,14 @@ describe('Parsing API description document', ->
     it('produces media type', ->
       assert.match(mediaType, reMediaType)
     )
-    it('the parse result contains annotation element', ->
-      assert.include(JSON.stringify(apiElements), '"annotation"')
+    it('the parse result contains annotation elements', ->
+      assert.isAbove(apiElements.annotations?.length, 0)
     )
-    it('the annotation is a warning', ->
-      assert.include(JSON.stringify(apiElements), '"warning"')
+    it('the annotations are warnings', ->
+      assert.equal(apiElements.warnings?.length, apiElements.annotations.length)
     )
-    it('the warning is about falling back to API Blueprint', ->
-      assert.include(JSON.stringify(apiElements), 'to API Blueprint')
+    it('the first warning is about falling back to API Blueprint', ->
+      assert.include(apiElements.warnings.get(0).toValue(), 'to API Blueprint')
     )
   )
 )

--- a/test/unit/parse-test.coffee
+++ b/test/unit/parse-test.coffee
@@ -33,12 +33,10 @@ describe('Parsing API description document', ->
         assert.match(mediaType, reMediaType)
       )
       it('the parse result is API Elements represented by minim objects', ->
-        assert.equal(apiElements.element, 'parseResult')
-        assert.isArray(apiElements.content)
-        assert.isObject(apiElementsToJson(apiElements))
+        assert.instanceOf(apiElements, fury.minim.elements.ParseResult)
       )
       it('the parse result contains no annotation elements', ->
-        assert.equal(apiElements.annotations?.length, 0)
+        assert.isTrue(apiElements.annotations?.isEmpty)
       )
       it('the parse result contains source map elements', ->
         assert.include(JSON.stringify(apiElementsToJson(apiElements)), '"sourceMap"')
@@ -69,7 +67,7 @@ describe('Parsing API description document', ->
         assert.match(mediaType, reMediaType)
       )
       it('the parse result contains annotation elements', ->
-        assert.isAbove(apiElements.annotations?.length, 0)
+        assert.isFalse(apiElements.annotations?.isEmpty)
       )
       it('the annotations are errors', ->
         assert.equal(apiElements.errors?.length, apiElements.annotations.length)
@@ -100,7 +98,7 @@ describe('Parsing API description document', ->
         assert.match(mediaType, reMediaType)
       )
       it('the parse result contains annotation elements', ->
-        assert.isAbove(apiElements.annotations?.length, 0)
+        assert.isFalse(apiElements.annotations?.isEmpty)
       )
       it('the annotations are warnings', ->
         assert.equal(apiElements.warnings?.length, apiElements.annotations.length)
@@ -159,13 +157,13 @@ describe('Parsing API description document', ->
       assert.match(mediaType, reMediaType)
     )
     it('the parse result contains annotation elements', ->
-      assert.isAbove(apiElements.annotations?.length, 0)
+      assert.isFalse(apiElements.annotations?.isEmpty)
     )
     it('the annotations are warnings', ->
       assert.equal(apiElements.warnings?.length, apiElements.annotations.length)
     )
     it('the first warning is about falling back to API Blueprint', ->
-      assert.include(apiElements.warnings.get(0).toValue(), 'to API Blueprint')
+      assert.include(apiElements.warnings.getValue(0), 'to API Blueprint')
     )
   )
 
@@ -191,13 +189,13 @@ describe('Parsing API description document', ->
       assert.match(mediaType, reMediaType)
     )
     it('the parse result contains annotation elements', ->
-      assert.isAbove(apiElements.annotations?.length, 0)
+      assert.isFalse(apiElements.annotations?.isEmpty)
     )
     it('the annotations are warnings', ->
       assert.equal(apiElements.warnings?.length, apiElements.annotations.length)
     )
     it('the first warning is about falling back to API Blueprint', ->
-      assert.include(apiElements.warnings.get(0).toValue(), 'to API Blueprint')
+      assert.include(apiElements.warnings.getValue(0), 'to API Blueprint')
     )
   )
 )


### PR DESCRIPTION
This change allows to use minim in the compilation process.