### PR TITLE
Remove Deckard Cain

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "caseless": "^0.12.0",
     "clone": "^2.1.1",
-    "deckardcain": "^0.3.2",
     "fury": "3.0.0-beta.3",
     "fury-adapter-apib-parser": "0.8.0",
     "fury-adapter-swagger": "0.12.0",

--- a/src/parse.coffee
+++ b/src/parse.coffee
@@ -1,4 +1,3 @@
-deckardcain = require('deckardcain')
 fury = require('fury')
 fury.use(require('fury-adapter-apib-parser'))
 fury.use(require('fury-adapter-swagger'))
@@ -14,9 +13,11 @@ createWarning = (message) ->
 
 parse = (source, callback) ->
   warning = null
-  mediaType = deckardcain.identify(source)
+  adapters = fury.detect(source)
 
-  unless mediaType
+  if adapters.length
+    mediaType = adapters[0].mediaTypes[0]
+  else
     mediaType = 'text/vnd.apiblueprint'
     warning = createWarning('''\
       Could not recognize API description format. \


### PR DESCRIPTION
With https://github.com/apiaryio/fury.js/pull/73/ the Deckard Cain functionality is now embedded in Fury.js.

**Review Note:** The assignment is @kylef _OR_ @michalholasek - whoever gets to this PR first, feel free to merge it in case of passing review.