### PR TITLE
Isolate URI compilation in a separate directory

### DIFF
--- a/src/compile-uri/compile-params.coffee
+++ b/src/compile-uri/compile-params.coffee
@@ -1,0 +1,33 @@
+fury = require('fury')
+
+{content} = require('../refract')
+
+
+module.exports = (hrefVariables) ->
+  parameters = {}
+
+  for member in content(hrefVariables) or []
+    {key, value} = content(member)
+
+    name = content(key)
+    types = (content(member.attributes?.typeAttributes) or [])
+
+    if value?.element is 'enum'
+      if value.attributes?.samples?.length and value.attributes?.samples[0].length
+        exampleValue = content(value.attributes.samples[0][0])
+      else
+        exampleValue = content(content(value)[0])
+      if value.attributes?.default?.length
+        defaultValue = content(value.attributes.default[0])
+    else
+      exampleValue = content(value)
+      if value.attributes?.default
+        defaultValue = content(value.attributes?.default)
+
+    parameters[name] =
+      required: 'required' in types
+      default: defaultValue
+      example: exampleValue
+      values: if value?.element is 'enum' then ({value: content(v)} for v in content(value)) else []
+
+  parameters

--- a/src/compile-uri/expand-uri-template.coffee
+++ b/src/compile-uri/expand-uri-template.coffee
@@ -1,8 +1,7 @@
-
 ut = require 'uri-template'
 
 
-expandUriTemplateWithParameters = (uriTemplate, parameters) ->
+module.exports = (uriTemplate, parameters) ->
   result =
     errors: []
     warnings: []
@@ -65,6 +64,3 @@ expandUriTemplateWithParameters = (uriTemplate, parameters) ->
       result.uri = parsed.expand(toExpand)
 
   return result
-
-
-module.exports = expandUriTemplateWithParameters

--- a/src/compile-uri/index.coffee
+++ b/src/compile-uri/index.coffee
@@ -1,0 +1,41 @@
+{parent, content} = require('../refract')
+
+compileParams = require('./compile-params')
+validateParams = require('./validate-params')
+expandUriTemplate = require('./expand-uri-template')
+
+
+module.exports = (parseResult, httpRequest) ->
+  resource = parent(httpRequest, parseResult, {element: 'resource'})
+  transition = parent(httpRequest, parseResult, {element: 'transition'})
+
+  cascade = [
+    resource.attributes
+    transition.attributes
+    httpRequest.attributes
+  ]
+
+  parameters = {}
+  annotations = {errors: [], warnings: []}
+  href = undefined
+
+  for attributes in cascade
+    href = content(attributes.href) if attributes?.href
+    for own name, parameter of compileParams(attributes?.hrefVariables)
+      parameters[name] = parameter
+
+  result = validateParams(parameters)
+  component = 'parametersValidation'
+  for error in result.errors
+    annotations.errors.push({component, message: error})
+  for warning in result.warnings
+    annotations.warnings.push({component, message: warning})
+
+  result = expandUriTemplate(href, parameters)
+  component = 'uriTemplateExpansion'
+  for error in result.errors
+    annotations.errors.push({component, message: error})
+  for warning in result.warnings
+    annotations.warnings.push({component, message: warning})
+
+  {uri: result.uri, annotations}

--- a/src/compile-uri/validate-params.coffee
+++ b/src/compile-uri/validate-params.coffee
@@ -1,5 +1,5 @@
 
-validateParameters = (params) ->
+module.exports = (params) ->
   result = {warnings: [], errors: []}
 
   for paramName, param of params
@@ -24,6 +24,3 @@ validateParameters = (params) ->
         result.errors.push(text)
 
   return result
-
-
-module.exports = validateParameters

--- a/src/compile.coffee
+++ b/src/compile.coffee
@@ -2,10 +2,9 @@ clone = require('clone')
 caseless = require('caseless')
 
 {child, children, parent, content} = require('./refract')
-validateParameters = require('./validate-parameters')
 detectTransactionExamples = require('./detect-transaction-examples')
-expandUriTemplateWithParameters = require('./expand-uri-template-with-parameters')
 apiElementsToRefract = require('./api-elements-to-refract')
+compileUri = require('./compile-uri')
 
 
 compile = (mediaType, apiElements, filename) ->
@@ -158,72 +157,6 @@ compileResponse = (httpResponse) ->
   response.schema = schema if schema
 
   response
-
-
-compileUri = (parseResult, httpRequest) ->
-  resource = parent(httpRequest, parseResult, {element: 'resource'})
-  transition = parent(httpRequest, parseResult, {element: 'transition'})
-
-  cascade = [
-    resource.attributes
-    transition.attributes
-    httpRequest.attributes
-  ]
-
-  parameters = {}
-  annotations = {errors: [], warnings: []}
-  href = undefined
-
-  for attributes in cascade
-    href = content(attributes.href) if attributes?.href
-    for own name, parameter of compileParameters(attributes?.hrefVariables)
-      parameters[name] = parameter
-
-  result = validateParameters(parameters)
-  component = 'parametersValidation'
-  for error in result.errors
-    annotations.errors.push({component, message: error})
-  for warning in result.warnings
-    annotations.warnings.push({component, message: warning})
-
-  result = expandUriTemplateWithParameters(href, parameters)
-  component = 'uriTemplateExpansion'
-  for error in result.errors
-    annotations.errors.push({component, message: error})
-  for warning in result.warnings
-    annotations.warnings.push({component, message: warning})
-
-  {uri: result.uri, annotations}
-
-
-compileParameters = (hrefVariables) ->
-  parameters = {}
-
-  for member in content(hrefVariables) or []
-    {key, value} = content(member)
-
-    name = content(key)
-    types = (content(member.attributes?.typeAttributes) or [])
-
-    if value?.element is 'enum'
-      if value.attributes?.samples?.length and value.attributes?.samples[0].length
-        exampleValue = content(value.attributes.samples[0][0])
-      else
-        exampleValue = content(content(value)[0])
-      if value.attributes?.default?.length
-        defaultValue = content(value.attributes.default[0])
-    else
-      exampleValue = content(value)
-      if value.attributes?.default
-        defaultValue = content(value.attributes?.default)
-
-    parameters[name] =
-      required: 'required' in types
-      default: defaultValue
-      example: exampleValue
-      values: if value?.element is 'enum' then ({value: content(v)} for v in content(value)) else []
-
-  parameters
 
 
 compileHeaders = (httpHeaders) ->

--- a/test/integration/compile-test.coffee
+++ b/test/integration/compile-test.coffee
@@ -1,3 +1,4 @@
+proxyquire = require('proxyquire').noPreserveCache()
 
 fixtures = require('../fixtures')
 createCompilationResultSchema = require('../schemas/compilation-result')
@@ -204,8 +205,10 @@ describe('compile() · all API description formats', ->
     message = '... dummy warning message ...'
 
     stubs =
-      './expand-uri-template-with-parameters': (args...) ->
-        {uri: '/honey?beekeeper=Honza', errors: [], warnings: [message]}
+      './compile-uri': proxyquire('../../src/compile-uri',
+        './expand-uri-template': (args...) ->
+          {uri: '/honey?beekeeper=Honza', errors: [], warnings: [message]}
+      )
 
     fixtures.ordinary.forEachDescribe(({source}) ->
       beforeEach((done) ->
@@ -284,7 +287,7 @@ describe('compile() · all API description formats', ->
   )
 
   describe('causing a warning in URI validation', ->
-    # Since 'validateParameters' doesn't actually return any warnings
+    # Since 'validateParams' doesn't actually return any warnings
     # (but could in the future), we need to pretend it's possible for this
     # test.
 
@@ -293,8 +296,10 @@ describe('compile() · all API description formats', ->
     message = '... dummy warning message ...'
 
     stubs =
-      './validate-parameters': (args...) ->
-        {errors: [], warnings: [message]}
+      './compile-uri': proxyquire('../../src/compile-uri',
+        './validate-params': (args...) ->
+          {errors: [], warnings: [message]}
+      )
 
     fixtures.ordinary.forEachDescribe(({source}) ->
       beforeEach((done) ->

--- a/test/unit/compile-uri/expand-uri-template-test.coffee
+++ b/test/unit/compile-uri/expand-uri-template-test.coffee
@@ -1,8 +1,8 @@
 {assert} = require 'chai'
 
-expandUriTemplateWithParameters = require '../../src/expand-uri-template-with-parameters'
+expandUriTemplate = require '../../../src/compile-uri/expand-uri-template'
 
-describe 'expandUriTemplateWithParameters', ->
+describe 'expandUriTemplate', ->
   data = null
   uriTemplate = ''
   parameters = ''
@@ -17,7 +17,7 @@ describe 'expandUriTemplateWithParameters', ->
         example: 'waldo'
         default: ''
 
-    data = expandUriTemplateWithParameters uriTemplate, parameters
+    data = expandUriTemplate uriTemplate, parameters
 
   it 'should return an object', ->
     assert.isObject data
@@ -42,7 +42,7 @@ describe 'expandUriTemplateWithParameters', ->
             example: 'waldo'
             default: ''
 
-        data = expandUriTemplateWithParameters uriTemplate, parameters
+        data = expandUriTemplate uriTemplate, parameters
 
       it 'it should return some errror', ->
         assert.notEqual data['errors'].length, 0
@@ -52,7 +52,7 @@ describe 'expandUriTemplateWithParameters', ->
       before ->
         uriTemplate = '/machines/waldo'
         parameters = {}
-        data = expandUriTemplateWithParameters uriTemplate, parameters
+        data = expandUriTemplate uriTemplate, parameters
 
       describe 'with no parameters given', ->
         it 'should return no error', ->
@@ -76,7 +76,7 @@ describe 'expandUriTemplateWithParameters', ->
               example: 'waldo'
               default: ''
 
-          data = expandUriTemplateWithParameters uriTemplate, parameters
+          data = expandUriTemplate uriTemplate, parameters
 
         it 'should return no error', ->
           assert.equal data['errors'].length, 0
@@ -95,7 +95,7 @@ describe 'expandUriTemplateWithParameters', ->
         before ->
           uriTemplate = '/machines/{name}'
           parameters = {}
-          data = expandUriTemplateWithParameters uriTemplate, parameters
+          data = expandUriTemplate uriTemplate, parameters
 
         it 'should return some warning', ->
           assert.notEqual data['warnings'].length, 0
@@ -133,7 +133,7 @@ describe 'expandUriTemplateWithParameters', ->
               example: 'wild'
               default: ''
 
-          data = expandUriTemplateWithParameters uriTemplate, parameters
+          data = expandUriTemplate uriTemplate, parameters
 
         it 'should return no error', ->
           assert.equal data['errors'].length, 0
@@ -158,7 +158,7 @@ describe 'expandUriTemplateWithParameters', ->
                 example: ''
                 default: ''
 
-            data = expandUriTemplateWithParameters uriTemplate, parameters
+            data = expandUriTemplate uriTemplate, parameters
 
           it 'should return no error', ->
             assert.equal data['errors'].length, 0
@@ -189,7 +189,7 @@ describe 'expandUriTemplateWithParameters', ->
                 example: 'example-one'
                 default: ''
 
-            data = expandUriTemplateWithParameters uriTemplate, parameters
+            data = expandUriTemplate uriTemplate, parameters
 
           it 'should return no error', ->
             assert.equal data['errors'].length, 0
@@ -214,7 +214,7 @@ describe 'expandUriTemplateWithParameters', ->
                 example: ''
                 default: 'example-one'
 
-            data = expandUriTemplateWithParameters uriTemplate, parameters
+            data = expandUriTemplate uriTemplate, parameters
 
           it 'should return no error', ->
             assert.equal data['errors'].length, 0
@@ -242,7 +242,7 @@ describe 'expandUriTemplateWithParameters', ->
                 example: 'example-one'
                 default: 'default-one'
 
-            data = expandUriTemplateWithParameters uriTemplate, parameters
+            data = expandUriTemplate uriTemplate, parameters
 
           it 'should return no error', ->
             assert.equal data['errors'].length, 0
@@ -270,7 +270,7 @@ describe 'expandUriTemplateWithParameters', ->
               example: 'example-one'
               default: ''
 
-          data = expandUriTemplateWithParameters uriTemplate, parameters
+          data = expandUriTemplate uriTemplate, parameters
 
         it 'should return no error', ->
           assert.equal data['errors'].length, 0
@@ -295,7 +295,7 @@ describe 'expandUriTemplateWithParameters', ->
                 default: 'default-one'
                 example: ''
 
-            data = expandUriTemplateWithParameters uriTemplate, parameters
+            data = expandUriTemplate uriTemplate, parameters
 
           it 'should return no error', ->
             assert.equal data['errors'].length, 0
@@ -320,7 +320,7 @@ describe 'expandUriTemplateWithParameters', ->
                 example: 'example-one'
                 default: 'default-one'
 
-            data = expandUriTemplateWithParameters uriTemplate, parameters
+            data = expandUriTemplate uriTemplate, parameters
 
           it 'should return no error', ->
             assert.equal data['errors'].length, 0
@@ -345,7 +345,7 @@ describe 'expandUriTemplateWithParameters', ->
                 default: ''
                 example: ''
 
-            data = expandUriTemplateWithParameters uriTemplate, parameters
+            data = expandUriTemplate uriTemplate, parameters
 
           it 'should return no error', ->
             assert.equal data['errors'].length, 0

--- a/test/unit/compile-uri/validate-parameters-test.coffee
+++ b/test/unit/compile-uri/validate-parameters-test.coffee
@@ -1,8 +1,8 @@
 {assert} = require 'chai'
 
-validateParameters = require '../../src/validate-parameters'
+validateParams = require '../../../src/compile-uri/validate-params'
 
-describe 'validateParameters', ->
+describe 'validateParams', ->
 
   it 'should return an object', ->
     params =
@@ -14,7 +14,7 @@ describe 'validateParameters', ->
         default: ''
         values: []
 
-    result = validateParameters params
+    result = validateParams params
     assert.isObject result
 
   describe 'when type is string and example is a parseable float', ->
@@ -28,7 +28,7 @@ describe 'validateParameters', ->
           default: ''
           values: []
 
-      result = validateParameters params
+      result = validateParams params
       message = result['errors'][0]
       assert.equal result['errors'].length, 0
 
@@ -45,7 +45,7 @@ describe 'validateParameters', ->
           default: ''
           values: []
 
-      result = validateParameters params
+      result = validateParams params
 
   describe 'when type is string and example is a not a parseable float', ->
     it 'should set no error', ->
@@ -58,7 +58,7 @@ describe 'validateParameters', ->
           default: ''
           values: []
 
-      result = validateParameters params
+      result = validateParams params
       assert.equal result['errors'].length, 0
 
   describe 'when type is number and example is a string', ->
@@ -72,7 +72,7 @@ describe 'validateParameters', ->
           default: ''
           values: []
 
-      result = validateParameters params
+      result = validateParams params
       message = result['errors'][0]
       assert.include message, 'name'
       assert.include message, 'number'
@@ -88,7 +88,7 @@ describe 'validateParameters', ->
           default: ''
           values: []
 
-      result = validateParameters params
+      result = validateParams params
       assert.equal result['errors'].length, 0
 
   describe 'when enum values are defined and example value is not one of enum values', ->
@@ -106,7 +106,7 @@ describe 'validateParameters', ->
             { "value": "C" }
           ]
 
-      result = validateParameters params
+      result = validateParams params
       message = result['errors'][0]
       assert.include message, 'name'
       assert.include message, 'enum'
@@ -126,7 +126,7 @@ describe 'validateParameters', ->
             { "value": "C" }
           ]
 
-      result = validateParameters params
+      result = validateParams params
       assert.equal result['errors'].length, 0
 
   describe 'when type is boolean and example value is not parseable bool', ->
@@ -140,7 +140,7 @@ describe 'validateParameters', ->
           default: ''
           values: []
 
-      result = validateParameters params
+      result = validateParams params
       message = result['errors'][0]
       assert.include message, 'name'
       assert.include message, 'boolean'
@@ -156,7 +156,7 @@ describe 'validateParameters', ->
           default: ''
           values: []
 
-      result = validateParameters params
+      result = validateParams params
       assert.equal result['errors'].length, 0
 
   describe 'when parameter is required', () ->
@@ -171,7 +171,7 @@ describe 'validateParameters', ->
             default: ''
             values: []
 
-        result = validateParameters params
+        result = validateParams params
         message = result['errors'][0]
         assert.include message, 'name'
         assert.include message, 'Required'
@@ -187,7 +187,7 @@ describe 'validateParameters', ->
             default: 'bagaboo'
             values: []
 
-        result = validateParameters params
+        result = validateParams params
         assert.equal result['errors'].length, 0
 
     describe 'and example value is not empty and default value is empty', () ->
@@ -201,7 +201,7 @@ describe 'validateParameters', ->
             default: ''
             values: []
 
-        result = validateParameters params
+        result = validateParams params
         assert.equal result['errors'].length, 0
 
   describe 'when parameter is not required', () ->
@@ -216,7 +216,7 @@ describe 'validateParameters', ->
             default: ''
             values: []
 
-        result = validateParameters params
+        result = validateParams params
         assert.equal result['errors'].length, 0
 
 
@@ -231,7 +231,7 @@ describe 'validateParameters', ->
             default: 'bagaboo'
             values: []
 
-        result = validateParameters params
+        result = validateParams params
         assert.equal result['errors'].length, 0
 
     describe 'and example value is not empty and default value is empty', () ->
@@ -245,6 +245,6 @@ describe 'validateParameters', ->
             default: ''
             values: []
 
-        result = validateParameters params
+        result = validateParams params
         assert.equal result['errors'].length, 0
 


### PR DESCRIPTION
The goal of this PR is to isolate everything related to compilation of the request URI to a separate directory. This part of Dredd transactions can and should work as a `API Elements Request -> URI` black box, which just takes input, returns output, and the rest of the library doesn't need to know any particular details about how the thing has been done.

This should

- help to clean up some internal interfaces
- help with adding more unit tests in the future
- and possibly, if we're ever so daring, with extracting this logic into a separate library, which also other teams could use (cc @JackuB @netmilk @kylef )