### PR TITLE
Support allOf in Swagger

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "clone": "^2.1.1",
     "fury": "3.0.0-beta.3",
     "fury-adapter-apib-parser": "0.8.0",
-    "fury-adapter-swagger": "0.12.0",
+    "fury-adapter-swagger": "^0.12.1",
     "minim": "0.18.1",
     "sift": "^3.3.10",
     "traverse": "^0.6.6",
@@ -45,7 +45,7 @@
     "mocha-lcov-reporter": "^1.3.0",
     "proxyquire": "^1.8.0",
     "semantic-release": "^6.3.6",
-    "sinon": "^2.2.0",
+    "sinon": "^2.4.1",
     "swagger-zoo": "^2.2.6",
     "tv4": "^1.3.0"
   },


### PR DESCRIPTION
This PR introduces support of `allOf` in Swagger into Dredd Transactions. It also causes the version number to bump automatically, which will release all refactoring from recent PRs. For that reason this would be merged ideally after https://github.com/apiaryio/dredd-transactions/pull/85 is merged.