### PR TITLE
Upgrade minim, fury.js, and fury adapters

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
   "dependencies": {
     "caseless": "^0.12.0",
     "clone": "^2.1.1",
-    "fury": "3.0.0-beta.3",
-    "fury-adapter-apib-parser": "0.8.0",
-    "fury-adapter-swagger": "0.12.0",
-    "minim": "0.18.1",
+    "fury": "^3.0.0-beta.4",
+    "fury-adapter-apib-parser": "^0.9.0",
+    "fury-adapter-swagger": "^0.13.1",
+    "minim": "^0.19.1",
     "sift": "^3.3.10",
     "traverse": "^0.6.6",
     "uri-template": "^1.0.0"

--- a/src/compile.coffee
+++ b/src/compile.coffee
@@ -61,9 +61,7 @@ findRelevantTransactions = (mediaType, refract, apiElements) ->
   # This gets deleted once we're fully on minim
   refractTransitions = children(refract, {element: 'transition'})
 
-  apiElements.findRecursive('transition').forEach((transitionElement, transitionNoElement) ->
-    transitionNo = transitionNoElement.toValue()
-
+  apiElements.findRecursive('transition').forEach((transitionElement, transitionNo) ->
     # This gets deleted once we're fully on minim
     refractTransition = refractTransitions[transitionNo]
     refractHttpTransactions = children(refractTransition, {element: 'httpTransaction'})
@@ -85,8 +83,7 @@ findRelevantTransactions = (mediaType, refract, apiElements) ->
       # each transaction example. We iterate over available transactions and
       # skip those, which are not first within a particular example.
       exampleNo = 0
-      transitionElement.transactions.forEach((httpTransactionElement, httpTransactionNoElement) ->
-        httpTransactionNo = httpTransactionNoElement.toValue()
+      transitionElement.transactions.forEach((httpTransactionElement, httpTransactionNo) ->
         httpTransactionExampleNo = exampleNumbersPerTransaction[httpTransactionNo]
 
         relevantTransaction =
@@ -101,9 +98,9 @@ findRelevantTransactions = (mediaType, refract, apiElements) ->
       )
     else
       # All other formats then API Blueprint
-      transitionElement.transactions.forEach((httpTransactionElement, httpTransactionNoElement) ->
+      transitionElement.transactions.forEach((httpTransactionElement, httpTransactionNo) ->
         relevantTransactions.push(
-          refract: refractHttpTransactions[httpTransactionNoElement.toValue()]
+          refract: refractHttpTransactions[httpTransactionNo]
           apiElements: httpTransactionElement
         )
       )

--- a/src/parse.coffee
+++ b/src/parse.coffee
@@ -32,6 +32,7 @@ parse = (source, callback) ->
 
     if apiElements
       apiElements.unshift(warning) if warning
+      apiElements.freeze() # Adds 'parent' properties, prevents mutation
     else
       apiElements = null
 


### PR DESCRIPTION
Adds support `allOf` in object JSON Schemas in Swagger when producing object data structure elements. Gets bug fixes in both Swagger and API Blueprint parsers.

Allows further development in https://github.com/apiaryio/dredd-transactions/pull/85 and https://github.com/apiaryio/dredd-transactions/pull/87. Closes #86