### PR TITLE
Do not destructure second argument before checking for error

### DIFF
--- a/test/integration/compile-api-blueprint-test.coffee
+++ b/test/integration/compile-api-blueprint-test.coffee
@@ -17,9 +17,10 @@ describe('compile() · API Blueprint', ->
     transactions = undefined
 
     beforeEach((done) ->
-      compileFixture(fixtures.missingTitleAnnotation.apiBlueprint, (args...) ->
-        [err, {warnings, transactions}] = args
-        done(err)
+      compileFixture(fixtures.missingTitleAnnotation.apiBlueprint, (err, compilationResult) ->
+        return done(err) if err
+        {warnings, transactions} = compilationResult
+        done()
       )
     )
 
@@ -56,9 +57,10 @@ describe('compile() · API Blueprint', ->
     transactions = undefined
 
     beforeEach((done) ->
-      compileFixture(fixtures.notSpecifiedInUriTemplateAnnotation.apiBlueprint, (args...) ->
-        [err, {warnings, transactions}] = args
-        done(err)
+      compileFixture(fixtures.notSpecifiedInUriTemplateAnnotation.apiBlueprint, (err, compilationResult) ->
+        return done(err) if err
+        {warnings, transactions} = compilationResult
+        done()
       )
     )
 

--- a/test/integration/compile-swagger-test.coffee
+++ b/test/integration/compile-swagger-test.coffee
@@ -14,9 +14,10 @@ describe('compile() · Swagger', ->
     transactions = undefined
 
     beforeEach((done) ->
-      compileFixture(fixtures.notSpecifiedInUriTemplateAnnotation.swagger, (args...) ->
-        [err, {errors, transactions}] = args
-        done(err)
+      compileFixture(fixtures.notSpecifiedInUriTemplateAnnotation.swagger, (err, compilationResult) ->
+        return done(err) if err
+        {errors, transactions} = compilationResult
+        done()
       )
     )
 
@@ -51,10 +52,10 @@ describe('compile() · Swagger', ->
     response = undefined
 
     beforeEach((done) ->
-      compileFixture(fixtures.produces.swagger, (args...) ->
-        [err, {transactions}] = args
-        {request, response} = transactions[0]
-        done(err)
+      compileFixture(fixtures.produces.swagger, (err, compilationResult) ->
+        return done(err) if err
+        {request, response} = compilationResult.transactions[0]
+        done()
       )
     )
 
@@ -77,10 +78,10 @@ describe('compile() · Swagger', ->
     response = undefined
 
     beforeEach((done) ->
-      compileFixture(fixtures.consumes.swagger, (args...) ->
-        [err, {transactions}] = args
-        {request, response} = transactions[0]
-        done(err)
+      compileFixture(fixtures.consumes.swagger, (err, compilationResult) ->
+        return done(err) if err
+        {request, response} = compilationResult.transactions[0]
+        done()
       )
     )
 

--- a/test/integration/compile-test.coffee
+++ b/test/integration/compile-test.coffee
@@ -42,9 +42,10 @@ describe('compile() · all API description formats', ->
       transactions = undefined
 
       beforeEach((done) ->
-        compileFixture(source, (args...) ->
-          [err, {errors, transactions}] = args
-          done(err)
+        compileFixture(source, (err, compilationResult) ->
+          return done(err) if err
+          {errors, transactions} = compilationResult
+          done()
         )
       )
 
@@ -86,9 +87,10 @@ describe('compile() · all API description formats', ->
 
     fixtures.uriExpansionAnnotation.forEachDescribe(({source}) ->
       beforeEach((done) ->
-        compileFixture(source, (args...) ->
-          [err, {errors, transactions}] = args
-          done(err)
+        compileFixture(source, (err, compilationResult) ->
+          return done(err) if err
+          {errors, transactions} = compilationResult
+          done()
         )
       )
 
@@ -124,9 +126,10 @@ describe('compile() · all API description formats', ->
 
     fixtures.uriValidationAnnotation.forEachDescribe(({source}) ->
       beforeEach((done) ->
-        compileFixture(source, (args...) ->
-          [err, {errors, transactions}] = args
-          done(err)
+        compileFixture(source, (err, compilationResult) ->
+          return done(err) if err
+          {errors, transactions} = compilationResult
+          done()
         )
       )
 
@@ -162,9 +165,10 @@ describe('compile() · all API description formats', ->
       transactions = undefined
 
       beforeEach((done) ->
-        compileFixture(source, (args...) ->
-          [err, {warnings, transactions}] = args
-          done(err)
+        compileFixture(source, (err, compilationResult) ->
+          return done(err) if err
+          {warnings, transactions} = compilationResult
+          done()
         )
       )
 
@@ -254,9 +258,10 @@ describe('compile() · all API description formats', ->
 
     fixtures.ambiguousParametersAnnotation.forEachDescribe(({source}) ->
       beforeEach((done) ->
-        compileFixture(source, (args...) ->
-          [err, {warnings, transactions}] = args
-          done(err)
+        compileFixture(source, (err, compilationResult) ->
+          return done(err) if err
+          {warnings, transactions} = compilationResult
+          done()
         )
       )
 

--- a/test/unit/parse-test.coffee
+++ b/test/unit/parse-test.coffee
@@ -17,8 +17,9 @@ describe('Parsing API description document', ->
       apiElements = undefined
 
       beforeEach((done) ->
-        parse(source, (args...) ->
-          [error, {mediaType, apiElements}] = args
+        parse(source, (err, parseResult) ->
+          error = err
+          {mediaType, apiElements} = parseResult if parseResult
           done()
         )
       )
@@ -51,8 +52,9 @@ describe('Parsing API description document', ->
       apiElements = undefined
 
       beforeEach((done) ->
-        parse(source, (args...) ->
-          [error, {mediaType, apiElements}] = args
+        parse(source, (err, parseResult) ->
+          error = err
+          {mediaType, apiElements} = parseResult if parseResult
           done()
         )
       )
@@ -82,8 +84,9 @@ describe('Parsing API description document', ->
       apiElements = undefined
 
       beforeEach((done) ->
-        parse(source, (args...) ->
-          [error, {mediaType, apiElements}] = args
+        parse(source, (err, parseResult) ->
+          error = err
+          {mediaType, apiElements} = parseResult if parseResult
           done()
         )
       )
@@ -115,8 +118,9 @@ describe('Parsing API description document', ->
       sinon.stub(fury, 'parse').callsFake((args...) ->
         args.pop()() # calling the callback with neither error or parse result
       )
-      parse('... dummy API description document ...', (args...) ->
-        [error, {mediaType, apiElements}] = args
+      parse('... dummy API description document ...', (err, parseResult) ->
+        error = err
+        {mediaType, apiElements} = parseResult if parseResult
         done()
       )
     )
@@ -141,8 +145,9 @@ describe('Parsing API description document', ->
     apiElements = undefined
 
     beforeEach((done) ->
-      parse('... dummy API description document ...', (args...) ->
-        [error, {mediaType, apiElements}] = args
+      parse('... dummy API description document ...', (err, parseResult) ->
+        error = err
+        {mediaType, apiElements} = parseResult if parseResult
         done()
       )
     )
@@ -173,8 +178,9 @@ describe('Parsing API description document', ->
     apiElements = undefined
 
     beforeEach((done) ->
-      parse(fixtures.unrecognizable.apiBlueprint, (args...) ->
-        [error, {mediaType, apiElements}] = args
+      parse(fixtures.unrecognizable.apiBlueprint, (err, parseResult) ->
+        error = err
+        {mediaType, apiElements} = parseResult if parseResult
         done()
       )
     )


### PR DESCRIPTION
Many callbacks in tests are getting arguments in form of (err, result). Then they're destructuring the second argument too early, before checking for error. This results in tests blowing up in case of errors instead of providing any kind of valuable information (error message, stack trace).