### PR TITLE
bug: Multiple query parameters in Swagger expand to `[object Object]`

### DIFF
--- a/test/fixtures/api-blueprint/example-parameter.apib
+++ b/test/fixtures/api-blueprint/example-parameter.apib
@@ -2,7 +2,7 @@ FORMAT: 1A
 
 # Beehive API
 
-## Honey [/honey{?beekeeper}]
+## Honey [/honey{?beekeeper,flavour*}]
 
 + Parameters
     + beekeeper: Honza (enum[string])
@@ -14,6 +14,12 @@ FORMAT: 1A
             + Honza
             + Dredd
         + Default: `Dredd`
+
+    + flavour: sweet (array[string])
+
+        + Members
+            + sweet
+            + spicy
 
 ### Remove [DELETE]
 

--- a/test/fixtures/swagger/example-parameter.yml
+++ b/test/fixtures/swagger/example-parameter.yml
@@ -24,6 +24,14 @@ paths:
             - Dredd
           x-example: Honza
           default: Dredd
+        - name: flavour
+          in: query
+          type: array
+          items:
+            type: string
+          collectionFormat: multi
+          x-example:
+            - sweet
       responses:
         200:
           description: pet response

--- a/test/integration/compile-test.coffee
+++ b/test/integration/compile-test.coffee
@@ -372,7 +372,7 @@ describe('compile() · all API description formats', ->
       )
 
       it('expands the request URI with the example value', ->
-        assert.equal(transaction.request.uri, '/honey?beekeeper=Honza')
+        assert.equal(transaction.request.uri, '/honey?beekeeper=Honza&flavour=sweet')
       )
     )
   )


### PR DESCRIPTION
This is a bug report with failing test attached.

I believe dredd supports multiple query parameters with x-example in Swagger (https://github.com/apiaryio/fury-adapter-swagger/pull/106).

When using multiple query parameters in Swagger like below:

~~~yaml
paths:
  /honey:
    get:
      parameters:
        - name: beekeeper
          in: query
          type: string
          enum:
            - Adam
            - Honza
            - Dredd
          x-example: Honza
          default: Dredd
        - name: flavour
          in: query
          type: array
          items:
            type: string
          collectionFormat: multi
          x-example:
            - sweet
~~~


dredd produces example URL like:

~~~
/honey?beekeeper=Honza&flavour=%5Bobject%20Object%5D
~~~

While the last parameter should be `flavour=sweet`.