### PR TITLE
Fix failing tests for detectTransactionExampleNumbers

### DIFF
--- a/test/unit/detect-transaction-example-numbers-test.coffee
+++ b/test/unit/detect-transaction-example-numbers-test.coffee
@@ -24,7 +24,7 @@ scenario = (description, {actionContent, examples, exampleNumbersPerTransaction}
     beforeEach((done) ->
       parse(apiBlueprint, (args...) ->
         [error, {mediaType, apiElements}] = args
-        transitionElements = apiElements.api.resourceGroups.first().resources.first().transitions.first()
+        transitionElements = apiElements.api.resourceGroups.get(0).resources.get(0).transitions.get(0)
         transactionExampleNumbers = detectTransactionExampleNumbers(transitionElements)
         done()
       )


### PR DESCRIPTION
[`ArrayElement`](https://github.com/refractproject/minim#arrayelement) no longer have `first()` method, we have to use `get(0)` method to get first element instead.