### PR TITLE
Handle array parameters when compiling params

### DIFF
--- a/test/unit/compile-uri/compile-params-test.coffee
+++ b/test/unit/compile-uri/compile-params-test.coffee
@@ -1,0 +1,199 @@
+{expect} = require 'chai'
+fury = new require 'fury'
+
+compileParams = require '../../../src/compile-uri/compile-params'
+
+describe 'compileParams', ->
+  it 'should compile a primitive href variable', ->
+    hrefVariables = new fury.minim.elements.HrefVariables()
+    hrefVariables.set('name', new fury.minim.elements.String())
+
+    parameters = compileParams(hrefVariables)
+
+    expect(parameters).to.deep.equal({
+      name: {
+        default: undefined,
+        example: undefined,
+        required: false,
+        values: []
+      }
+    })
+
+  it 'should compile a required href variable', ->
+    hrefVariables = new fury.minim.elements.HrefVariables()
+    hrefVariables.set('name', 'Doe')
+    hrefVariables.getMember('name').attributes.set('typeAttributes', ['required'])
+
+    parameters = compileParams(hrefVariables)
+
+    expect(parameters).to.deep.equal({
+      name: {
+        default: undefined,
+        example: 'Doe',
+        required: true,
+        values: []
+      }
+    })
+
+  it 'should compile a primitive href variable with value', ->
+    hrefVariables = new fury.minim.elements.HrefVariables()
+    hrefVariables.set('name', 'Doe')
+
+    parameters = compileParams(hrefVariables)
+
+    expect(parameters).to.deep.equal({
+      name: {
+        default: undefined,
+        example: 'Doe',
+        required: false,
+        values: []
+      }
+    })
+
+  it 'should compile a primitive href variable with default', ->
+    hrefVariables = new fury.minim.elements.HrefVariables()
+    hrefVariables.set('name', new fury.minim.elements.String())
+    hrefVariables.get('name').attributes.set('default', 'Unknown')
+
+    parameters = compileParams(hrefVariables)
+
+    expect(parameters).to.deep.equal({
+      name: {
+        default: 'Unknown',
+        example: undefined,
+        required: false,
+        values: []
+      }
+    })
+
+  it 'should compile an array href variable', ->
+    hrefVariables = new fury.minim.elements.HrefVariables()
+    hrefVariables.set('names', [])
+
+    parameters = compileParams(hrefVariables)
+
+    expect(parameters).to.deep.equal({
+      names: {
+        default: undefined,
+        example: [],
+        required: false,
+        values: []
+      }
+    })
+
+  it 'should compile an array href variable with values', ->
+    hrefVariables = new fury.minim.elements.HrefVariables()
+    hrefVariables.set('names', ['One', 'Two'])
+
+    parameters = compileParams(hrefVariables)
+
+    expect(parameters).to.deep.equal({
+      names: {
+        default: undefined,
+        example: ['One', 'Two'],
+        required: false,
+        values: []
+      }
+    })
+
+  it 'should compile an array href variable with default', ->
+    hrefVariables = new fury.minim.elements.HrefVariables()
+    hrefVariables.set('names', [])
+    hrefVariables.get('names').attributes.set('default', ['Unknown'])
+
+    parameters = compileParams(hrefVariables)
+
+    expect(parameters).to.deep.equal({
+      names: {
+        default: ['Unknown'],
+        example: [],
+        required: false,
+        values: []
+      }
+    })
+
+  it 'should compile an array href variable with values', ->
+    hrefVariables = new fury.minim.elements.HrefVariables()
+    hrefVariables.set('names', ['One', 'Two'])
+
+    parameters = compileParams(hrefVariables)
+
+    expect(parameters).to.deep.equal({
+      names: {
+        default: undefined,
+        example: ['One', 'Two'],
+        required: false,
+        values: []
+      }
+    })
+
+  it 'should compile an array href variable with default', ->
+    hrefVariables = new fury.minim.elements.HrefVariables()
+    hrefVariables.set('names', [])
+    hrefVariables.get('names').attributes.set('default', ['Unknown'])
+
+    parameters = compileParams(hrefVariables)
+
+    expect(parameters).to.deep.equal({
+      names: {
+        default: ['Unknown'],
+        example: [],
+        required: false,
+        values: []
+      }
+    })
+
+  it 'should compile an enum href variable', ->
+    hrefVariables = new fury.minim.elements.HrefVariables()
+    value = new fury.minim.elements.Element()
+    value.element = 'enum'
+    value.attributes.set('enumerations', ['ascending', 'decending'])
+    hrefVariables.set('order', value)
+
+    parameters = compileParams(hrefVariables)
+
+    expect(parameters).to.deep.equal({
+      order: {
+        default: undefined,
+        example: 'ascending',
+        required: false,
+        values: ['ascending', 'decending']
+      }
+    })
+
+  it 'should compile an enum href variable with values', ->
+    hrefVariables = new fury.minim.elements.HrefVariables()
+    value = new fury.minim.elements.Element('decending')
+    value.element = 'enum'
+    value.attributes.set('enumerations', ['ascending', 'decending'])
+    hrefVariables.set('order', value)
+
+    parameters = compileParams(hrefVariables)
+
+    expect(parameters).to.deep.equal({
+      order: {
+        default: undefined,
+        example: 'decending',
+        required: false,
+        values: ['ascending', 'decending']
+      }
+    })
+
+  it 'should compile an enum href variable with default', ->
+    hrefVariables = new fury.minim.elements.HrefVariables()
+    value = new fury.minim.elements.Element()
+    value.element = 'enum'
+    value.attributes.set('enumerations', ['ascending', 'decending'])
+    value.attributes.set('default', 'decending')
+    hrefVariables.set('order', value)
+
+    parameters = compileParams(hrefVariables)
+
+    expect(parameters).to.deep.equal({
+      order: {
+        default: 'decending',
+        example: 'ascending',
+        required: false,
+        values: ['ascending', 'decending']
+      }
+    })


### PR DESCRIPTION
This PR also refactors the parameter compiler to accept Minim Elements directly and internally uses Minim elements to simplify the logic and to make it easier to fix the bug.

When the given input is not a minim element it will be converted, this conversion is temporary and should be removed once Dredd Transactions completely consumes Minim elements.

Fixes https://github.com/apiaryio/dredd-transactions/pull/90