### PR TITLE
Compile URI using minim

### DIFF
--- a/src/compile-uri/compile-params.coffee
+++ b/src/compile-uri/compile-params.coffee
@@ -7,22 +7,18 @@
 # Convert a Href Variables element to a Dredd Representation
 # Accepts both hrefVariables minim element, and 0.6 serialised Refract hrefVariables
 module.exports = (hrefVariables) ->
-  parameters = {}
+  params = {}
+  return params unless hrefVariables
 
-  if hrefVariables
-    if not (hrefVariables instanceof Element)
-      hrefVariables = deserialize(hrefVariables)
+  hrefVariables.forEach((value, key, member) ->
+    name = key.toValue()
+    typeAttributesElement = member.attributes.get('typeAttributes')?.toValue() or []
+    values = value.attributes.get('enumerations')?.toValue() or []
 
-    hrefVariables.forEach((value, key, member) ->
-      name = key.toValue()
-      typeAttributes = member.attributes.get('typeAttributes')?.toValue() or []
-      values = value.attributes.get('enumerations')?.toValue() or []
-
-      parameters[name] =
-        required: 'required' in typeAttributes
-        default: value.attributes.get('default')?.toValue()
-        example: value.toValue() or values[0]
-        values: values
-    )
-
-  parameters
+    params[name] =
+      required: 'required' in typeAttributesElement
+      default: value.attributes.get('default')?.toValue()
+      example: value.toValue() or values[0]
+      values: values
+  )
+  return params

--- a/src/compile-uri/index.coffee
+++ b/src/compile-uri/index.coffee
@@ -1,37 +1,36 @@
-{parent, content} = require('../refract')
-
 compileParams = require('./compile-params')
 validateParams = require('./validate-params')
 expandUriTemplate = require('./expand-uri-template')
 
+{parent} = require('../refract')
+{deserialize} = require('../refract-serialization')
 
-module.exports = (parseResult, httpRequest) ->
-  resource = parent(httpRequest, parseResult, {element: 'resource'})
-  transition = parent(httpRequest, parseResult, {element: 'transition'})
 
-  cascade = [
-    resource.attributes
-    transition.attributes
-    httpRequest.attributes
-  ]
-
-  parameters = {}
+module.exports = (refract, refractHttpRequest) ->
   annotations = {errors: [], warnings: []}
-  href = undefined
+  cascade = getCascade(refract, refractHttpRequest)
 
-  for attributes in cascade
-    href = content(attributes.href) if attributes?.href
-    for own name, parameter of compileParams(attributes?.hrefVariables)
-      parameters[name] = parameter
+  href = cascade
+    .map((element) -> element.href?.toValue())
+    .filter((href) -> !!href)
+    .pop()
 
-  result = validateParams(parameters)
+  # Support for 'httpRequest' parameters is experimental. The element does
+  # not have the '.hrefVariables' convenience property yet. If it's added in
+  # the future, '.attributes.get('hrefVariables')' can be replaced
+  # with '.hrefVariables'.
+  params = cascade
+    .map((element) -> compileParams(element.attributes.get('hrefVariables')))
+    .reduce(overrideParams, {})
+
+  result = validateParams(params)
   component = 'parametersValidation'
   for error in result.errors
     annotations.errors.push({component, message: error})
   for warning in result.warnings
     annotations.warnings.push({component, message: warning})
 
-  result = expandUriTemplate(href, parameters)
+  result = expandUriTemplate(href, params)
   component = 'uriTemplateExpansion'
   for error in result.errors
     annotations.errors.push({component, message: error})
@@ -39,3 +38,19 @@ module.exports = (parseResult, httpRequest) ->
     annotations.warnings.push({component, message: warning})
 
   {uri: result.uri, annotations}
+
+
+overrideParams = (params, paramsToOverride) ->
+  params[name] = param for own name, param of paramsToOverride
+  return params
+
+
+# Temporary helper, until the interface of 'compileUri' changes to API Elements
+getCascade = (refract, refractHttpRequest) ->
+  refractResource = parent(refractHttpRequest, refract, {element: 'resource'})
+  refractTransition = parent(refractHttpRequest, refract, {element: 'transition'})
+  return [
+    deserialize(refractResource)
+    deserialize(refractTransition)
+    deserialize(refractHttpRequest)
+  ]


### PR DESCRIPTION
This PR makes sure everything in the `compile-uri` directory uses minim instead of raw refract.

The changes are built on top of https://github.com/apiaryio/dredd-transactions/pull/96, so once that one gets merged, this PR needs to be rebased. This PR supersedes and closes https://github.com/apiaryio/dredd-transactions/pull/85.