### PR TITLE
Fix enum regressions

### DIFF
--- a/src/compile-uri/compile-params.coffee
+++ b/src/compile-uri/compile-params.coffee
@@ -1,11 +1,9 @@
 {Element} = require('minim')
-{deserialize} = require('../refract-serialization')
 
+{deserialize} = require('../refract-serialization')
 {content} = require('../refract')
 
 
-# Convert a Href Variables element to a Dredd Representation
-# Accepts both hrefVariables minim element, and 0.6 serialised Refract hrefVariables
 module.exports = (hrefVariables) ->
   params = {}
   return params unless hrefVariables

--- a/src/compile-uri/expand-uri-template.coffee
+++ b/src/compile-uri/expand-uri-template.coffee
@@ -1,7 +1,7 @@
 ut = require 'uri-template'
 
 
-module.exports = (uriTemplate, parameters) ->
+module.exports = (uriTemplate, params) ->
   result =
     errors: []
     warnings: []
@@ -28,7 +28,7 @@ module.exports = (uriTemplate, parameters) ->
     ambiguous = false
 
     for uriParameter in uriParameters
-      if Object.keys(parameters).indexOf(uriParameter) is -1
+      if Object.keys(params).indexOf(uriParameter) is -1
         ambiguous = true
         result.warnings.push("""\
           Ambiguous URI parameter in template: #{uriTemplate}
@@ -38,7 +38,7 @@ module.exports = (uriTemplate, parameters) ->
     unless ambiguous
       toExpand = {}
       for uriParameter in uriParameters
-        param = parameters[uriParameter]
+        param = params[uriParameter]
 
         if param.example
           toExpand[uriParameter] = param.example

--- a/src/compile-uri/validate-params.coffee
+++ b/src/compile-uri/validate-params.coffee
@@ -18,8 +18,7 @@ module.exports = (params) ->
           result.errors.push(text)
 
     if param.values.length > 0
-      values = param.values.map((value) -> value.value)
-      unless values.indexOf(param.example) > -1
+      unless param.values.indexOf(param.example) > -1
         text = "URI parameter '#{paramName}' example value is not one of enum values."
         result.errors.push(text)
 

--- a/test/fixtures/api-blueprint/ambiguous-parameters-annotation.apib
+++ b/test/fixtures/api-blueprint/ambiguous-parameters-annotation.apib
@@ -2,7 +2,10 @@ FORMAT: 1A
 
 # Beehive API
 
-## Honey [/honey{?beekeeper}]
+## Honey [/honey/{id}]
+
++ Parameters
+    + id
 
 ### Remove [DELETE]
 

--- a/test/fixtures/api-blueprint/enum-parameter-example.apib
+++ b/test/fixtures/api-blueprint/enum-parameter-example.apib
@@ -1,0 +1,17 @@
+FORMAT: 1A
+
+# Beehive API
+
+## Honey [/honey{?beekeeper}]
+
++ Parameters
+    + beekeeper: Honza (enum[string])
+        + Members
+            + Adam
+            + Honza
+
+### Remove [DELETE]
+
++ Request (application/json)
+
++ Response 200

--- a/test/fixtures/api-blueprint/enum-parameter-unlisted-example.apib
+++ b/test/fixtures/api-blueprint/enum-parameter-unlisted-example.apib
@@ -1,0 +1,17 @@
+FORMAT: 1A
+
+# Beehive API
+
+## Honey [/honey{?beekeeper}]
+
++ Parameters
+    + beekeeper: Pavan (enum[string])
+        + Members
+            + Adam
+            + Honza
+
+### Remove [DELETE]
+
++ Request (application/json)
+
++ Response 200

--- a/test/fixtures/api-blueprint/example-parameters.apib
+++ b/test/fixtures/api-blueprint/example-parameters.apib
@@ -2,7 +2,7 @@ FORMAT: 1A
 
 # Beehive API
 
-## Honey [/honey{?beekeeper,flavour*}]
+## Honey [/honey{?beekeeper,flavour}]
 
 + Parameters
     + beekeeper: Honza (enum[string], optional)
@@ -15,7 +15,7 @@ FORMAT: 1A
             + Dredd
         + Default: Dredd
 
-    + flavour: sweet (array[string])
+    + flavour: spicy (enum[string])
         + Members
             + sweet
             + spicy

--- a/test/fixtures/api-blueprint/example-parameters.apib
+++ b/test/fixtures/api-blueprint/example-parameters.apib
@@ -5,7 +5,7 @@ FORMAT: 1A
 ## Honey [/honey{?beekeeper,flavour*}]
 
 + Parameters
-    + beekeeper: Honza (enum[string])
+    + beekeeper: Honza (enum[string], optional)
 
         Description...
 
@@ -13,10 +13,9 @@ FORMAT: 1A
             + Adam
             + Honza
             + Dredd
-        + Default: `Dredd`
+        + Default: Dredd
 
     + flavour: sweet (array[string])
-
         + Members
             + sweet
             + spicy

--- a/test/fixtures/index.coffee
+++ b/test/fixtures/index.coffee
@@ -95,6 +95,14 @@ fixtures =
     apiBlueprint: fromFile('./api-blueprint/enum-parameter.apib')
     swagger: fromFile('./swagger/enum-parameter.yml')
   )
+  enumParameterExample: fixture(
+    apiBlueprint: fromFile('./api-blueprint/enum-parameter-example.apib')
+    swagger: fromFile('./swagger/enum-parameter-example.yml')
+  )
+  enumParameterUnlistedExample: fixture(
+    apiBlueprint: fromFile('./api-blueprint/enum-parameter-unlisted-example.apib')
+    swagger: fromFile('./swagger/enum-parameter-unlisted-example.yml')
+  )
   responseSchema: fixture(
     apiBlueprint: fromFile('./api-blueprint/response-schema.apib')
     swagger: fromSwaggerZoo('schema-reference')

--- a/test/fixtures/swagger/enum-parameter-example.yml
+++ b/test/fixtures/swagger/enum-parameter-example.yml
@@ -21,18 +21,7 @@ paths:
           enum:
             - Adam
             - Honza
-            - Dredd
           x-example: Honza
-          default: Dredd
-        - name: flavour
-          in: query
-          type: array
-          items:
-            type: string
-          collectionFormat: multi
-          x-example:
-            - sweet
-            - spicy
       responses:
         200:
           description: pet response

--- a/test/fixtures/swagger/enum-parameter-unlisted-example.yml
+++ b/test/fixtures/swagger/enum-parameter-unlisted-example.yml
@@ -21,18 +21,7 @@ paths:
           enum:
             - Adam
             - Honza
-            - Dredd
-          x-example: Honza
-          default: Dredd
-        - name: flavour
-          in: query
-          type: array
-          items:
-            type: string
-          collectionFormat: multi
-          x-example:
-            - sweet
-            - spicy
+          x-example: Pavan
       responses:
         200:
           description: pet response

--- a/test/fixtures/swagger/example-parameters.yml
+++ b/test/fixtures/swagger/example-parameters.yml
@@ -26,13 +26,11 @@ paths:
           default: Dredd
         - name: flavour
           in: query
-          type: array
-          items:
-            type: string
-          collectionFormat: multi
-          x-example:
+          type: string
+          enum:
             - sweet
             - spicy
+          x-example: spicy
       responses:
         200:
           description: pet response

--- a/test/integration/compile-api-blueprint-test.coffee
+++ b/test/integration/compile-api-blueprint-test.coffee
@@ -23,7 +23,7 @@ describe('compile() · API Blueprint', ->
     )
 
     it('is compiled into zero transactions', ->
-      assert.equal(compilationResult.transactions.length, 0)
+      assert.deepEqual(compilationResult.transactions, [])
     )
     it('is compiled with one warning', ->
       assert.equal(compilationResult.warnings.length, 1)

--- a/test/integration/compile-api-blueprint-test.coffee
+++ b/test/integration/compile-api-blueprint-test.coffee
@@ -13,39 +13,40 @@ describe('compile() · API Blueprint', ->
   originSchema = createOriginSchema()
 
   describe('causing a \'missing title\' warning', ->
-    warnings = undefined
-    transactions = undefined
+    compilationResult = undefined
 
     beforeEach((done) ->
-      compileFixture(fixtures.missingTitleAnnotation.apiBlueprint, (err, compilationResult) ->
-        return done(err) if err
-        {warnings, transactions} = compilationResult
-        done()
+      compileFixture(fixtures.missingTitleAnnotation.apiBlueprint, (args...) ->
+        [err, compilationResult] = args
+        done(err)
       )
     )
 
     it('is compiled into zero transactions', ->
-      assert.equal(transactions.length, 0)
+      assert.equal(compilationResult.transactions.length, 0)
     )
     it('is compiled with one warning', ->
-      assert.equal(warnings.length, 1)
+      assert.equal(compilationResult.warnings.length, 1)
     )
     context('the warning', ->
       it('comes from parser', ->
-        assert.equal(warnings[0].component, 'apiDescriptionParser')
+        assert.equal(compilationResult.warnings[0].component, 'apiDescriptionParser')
       )
       it('has code', ->
-        assert.isNumber(warnings[0].code)
+        assert.isNumber(compilationResult.warnings[0].code)
       )
       it('has message', ->
-        assert.include(warnings[0].message.toLowerCase(), 'expected api name')
+        assert.include(compilationResult.warnings[0].message.toLowerCase(), 'expected api name')
       )
       it('has location', ->
-        assert.jsonSchema(warnings[0].location, locationSchema)
+        assert.jsonSchema(compilationResult.warnings[0].location, locationSchema)
       )
       it('has no origin', ->
-        assert.isUndefined(warnings[0].origin)
+        assert.isUndefined(compilationResult.warnings[0].origin)
       )
+    )
+    it('is compiled with no errors', ->
+      assert.deepEqual(compilationResult.errors, [])
     )
   )
 
@@ -53,46 +54,47 @@ describe('compile() · API Blueprint', ->
     # The warning was previously handled by compiler, but now parser should
     # already provide the same kind of warning.
 
-    warnings = undefined
-    transactions = undefined
+    compilationResult = undefined
 
     beforeEach((done) ->
-      compileFixture(fixtures.notSpecifiedInUriTemplateAnnotation.apiBlueprint, (err, compilationResult) ->
-        return done(err) if err
-        {warnings, transactions} = compilationResult
-        done()
+      compileFixture(fixtures.notSpecifiedInUriTemplateAnnotation.apiBlueprint, (args...) ->
+        [err, compilationResult] = args
+        done(err)
       )
     )
 
     it('is compiled into expected number of transactions', ->
-      assert.equal(transactions.length, 1)
+      assert.equal(compilationResult.transactions.length, 1)
     )
     it('is compiled with a single warning', ->
-      assert.equal(warnings.length, 1)
+      assert.equal(compilationResult.warnings.length, 1)
     )
     context('the warning', ->
       it('comes from parser', ->
-        assert.equal(warnings[0].component, 'apiDescriptionParser')
+        assert.equal(compilationResult.warnings[0].component, 'apiDescriptionParser')
       )
       it('has code', ->
-        assert.isNumber(warnings[0].code)
+        assert.isNumber(compilationResult.warnings[0].code)
       )
       it('has message', ->
-        assert.include(warnings[0].message.toLowerCase(), 'not found within')
-        assert.include(warnings[0].message.toLowerCase(), 'uri template')
+        assert.include(compilationResult.warnings[0].message.toLowerCase(), 'not found within')
+        assert.include(compilationResult.warnings[0].message.toLowerCase(), 'uri template')
       )
       it('has location', ->
-        assert.jsonSchema(warnings[0].location, locationSchema)
+        assert.jsonSchema(compilationResult.warnings[0].location, locationSchema)
       )
       it('has no origin', ->
-        assert.isUndefined(warnings[0].origin)
+        assert.isUndefined(compilationResult.warnings[0].origin)
       )
+    )
+    it('is compiled with no errors', ->
+      assert.deepEqual(compilationResult.errors, [])
     )
   )
 
   describe('with multiple transaction examples', ->
     detectTransactionExampleNumbers = sinon.spy(require('../../src/detect-transaction-example-numbers'))
-    transactions = undefined
+    compilationResult = undefined
     expected = [
       {exampleName: '', requestContentType: 'application/json', responseStatusCode: 200}
       {exampleName: 'Example 1', requestContentType: 'application/json', responseStatusCode: 200}
@@ -101,10 +103,8 @@ describe('compile() · API Blueprint', ->
 
     beforeEach((done) ->
       stubs = {'./detect-transaction-example-numbers': detectTransactionExampleNumbers}
-
       compileFixture(fixtures.multipleTransactionExamples.apiBlueprint, {stubs}, (args...) ->
         [err, compilationResult] = args
-        transactions = compilationResult.transactions
         done(err)
       )
     )
@@ -113,7 +113,7 @@ describe('compile() · API Blueprint', ->
       assert.isTrue(detectTransactionExampleNumbers.called)
     )
     it('is compiled into expected number of transactions', ->
-      assert.equal(transactions.length, expected.length)
+      assert.equal(compilationResult.transactions.length, expected.length)
     )
     for expectations, i in expected
       do (expectations, i) ->
@@ -122,36 +122,39 @@ describe('compile() · API Blueprint', ->
 
           it("is identified as part of #{JSON.stringify(exampleName)}", ->
             assert.equal(
-              transactions[i].origin.exampleName,
+              compilationResult.transactions[i].origin.exampleName,
               exampleName
             )
           )
           it("has request with Content-Type: #{requestContentType}", ->
             assert.equal(
-              transactions[i].request.headers['Content-Type'].value,
+              compilationResult.transactions[i].request.headers['Content-Type'].value,
               requestContentType
             )
           )
           it("has response with status code #{responseStatusCode}", ->
             assert.equal(
-              transactions[i].response.status,
+              compilationResult.transactions[i].response.status,
               responseStatusCode
             )
           )
         )
+    it('is compiled with no warnings', ->
+      assert.deepEqual(compilationResult.warnings, [])
+    )
+    it('is compiled with no errors', ->
+      assert.deepEqual(compilationResult.errors, [])
+    )
   )
 
   describe('without multiple transaction examples', ->
     detectTransactionExampleNumbers = sinon.spy(require('../../src/detect-transaction-example-numbers'))
     compilationResult = undefined
-    transaction = undefined
 
     beforeEach((done) ->
       stubs = {'./detect-transaction-example-numbers': detectTransactionExampleNumbers}
-
       compileFixture(fixtures.oneTransactionExample.apiBlueprint, {stubs}, (args...) ->
         [err, compilationResult] = args
-        transaction = compilationResult.transactions[0]
         done(err)
       )
     )
@@ -164,102 +167,120 @@ describe('compile() · API Blueprint', ->
     )
     context('the transaction', ->
       it("is identified as part of no example in \'origin\'", ->
-        assert.equal(transaction.origin.exampleName, '')
+        assert.equal(compilationResult.transactions[0].origin.exampleName, '')
       )
       it("is identified as part of Example 1 in \'pathOrigin\'", ->
-        assert.equal(transaction.pathOrigin.exampleName, 'Example 1')
+        assert.equal(compilationResult.transactions[0].pathOrigin.exampleName, 'Example 1')
       )
+    )
+    it('is compiled with no warnings', ->
+      assert.deepEqual(compilationResult.warnings, [])
+    )
+    it('is compiled with no errors', ->
+      assert.deepEqual(compilationResult.errors, [])
     )
   )
 
   describe('with arbitrary action', ->
-    transaction0 = undefined
-    transaction1 = undefined
+    compilationResult = undefined
     filename = 'apiDescription.apib'
 
     beforeEach((done) ->
       compileFixture(fixtures.arbitraryAction.apiBlueprint, {filename}, (args...) ->
         [err, compilationResult] = args
-        [transaction0, transaction1] = compilationResult.transactions
         done(err)
       )
     )
 
+    it('is compiled with no warnings', ->
+      assert.deepEqual(compilationResult.warnings, [])
+    )
+    it('is compiled with no errors', ->
+      assert.deepEqual(compilationResult.errors, [])
+    )
     context('action within a resource', ->
       it('has URI inherited from the resource', ->
-        assert.equal(transaction0.request.uri, '/resource/1')
+        assert.equal(compilationResult.transactions[0].request.uri, '/resource/1')
       )
       it('has its method', ->
-        assert.equal(transaction0.request.method, 'GET')
+        assert.equal(compilationResult.transactions[0].request.method, 'GET')
       )
     )
-
     context('arbitrary action', ->
       it('has its own URI', ->
-        assert.equal(transaction1.request.uri, '/arbitrary/sample')
+        assert.equal(compilationResult.transactions[1].request.uri, '/arbitrary/sample')
       )
       it('has its method', ->
-        assert.equal(transaction1.request.method, 'POST')
+        assert.equal(compilationResult.transactions[1].request.method, 'POST')
       )
     )
   )
 
   describe('without sections', ->
-    transaction = undefined
+    compilationResult = undefined
     filename = 'apiDescription.apib'
 
     beforeEach((done) ->
       compileFixture(fixtures.withoutSections.apiBlueprint, {filename}, (args...) ->
         [err, compilationResult] = args
-        transaction = compilationResult.transactions[0]
         done(err)
       )
     )
 
+    it('is compiled with no warnings', ->
+      assert.deepEqual(compilationResult.warnings, [])
+    )
+    it('is compiled with no errors', ->
+      assert.deepEqual(compilationResult.errors, [])
+    )
     context('\'origin\'', ->
       it('uses filename as API name', ->
-        assert.equal(transaction.origin.apiName, filename)
+        assert.equal(compilationResult.transactions[0].origin.apiName, filename)
       )
       it('uses empty string as resource group name', ->
-        assert.equal(transaction.origin.resourceGroupName, '')
+        assert.equal(compilationResult.transactions[0].origin.resourceGroupName, '')
       )
       it('uses URI as resource name', ->
-        assert.equal(transaction.origin.resourceName, '/message')
+        assert.equal(compilationResult.transactions[0].origin.resourceName, '/message')
       )
       it('uses method as action name', ->
-        assert.equal(transaction.origin.actionName, 'GET')
+        assert.equal(compilationResult.transactions[0].origin.actionName, 'GET')
       )
     )
-
     context('\'pathOrigin\'', ->
       it('uses empty string as API name', ->
-        assert.equal(transaction.pathOrigin.apiName, '')
+        assert.equal(compilationResult.transactions[0].pathOrigin.apiName, '')
       )
       it('uses empty string as resource group name', ->
-        assert.equal(transaction.pathOrigin.resourceGroupName, '')
+        assert.equal(compilationResult.transactions[0].pathOrigin.resourceGroupName, '')
       )
       it('uses URI as resource name', ->
-        assert.equal(transaction.pathOrigin.resourceName, '/message')
+        assert.equal(compilationResult.transactions[0].pathOrigin.resourceName, '/message')
       )
       it('uses method as action name', ->
-        assert.equal(transaction.pathOrigin.actionName, 'GET')
+        assert.equal(compilationResult.transactions[0].pathOrigin.actionName, 'GET')
       )
     )
   )
 
   describe('with different sample and default value of URI parameter', ->
-    transaction = undefined
+    compilationResult = undefined
 
     beforeEach((done) ->
       compileFixture(fixtures.preferSample.apiBlueprint, (args...) ->
         [err, compilationResult] = args
-        transaction = compilationResult.transactions[0]
         done(err)
       )
     )
 
+    it('is compiled with no warnings', ->
+      assert.deepEqual(compilationResult.warnings, [])
+    )
+    it.skip('is compiled with no errors', ->
+      assert.deepEqual(compilationResult.errors, [])
+    )
     it('expands the request URI using the sample value', ->
-      assert.equal(transaction.request.uri, '/honey?beekeeper=Pavan')
+      assert.equal(compilationResult.transactions[0].request.uri, '/honey?beekeeper=Pavan')
     )
   )
 )

--- a/test/integration/compile-api-blueprint-test.coffee
+++ b/test/integration/compile-api-blueprint-test.coffee
@@ -276,7 +276,7 @@ describe('compile() · API Blueprint', ->
     it('is compiled with no warnings', ->
       assert.deepEqual(compilationResult.warnings, [])
     )
-    it.skip('is compiled with no errors', ->
+    it('is compiled with no errors', ->
       assert.deepEqual(compilationResult.errors, [])
     )
     it('expands the request URI using the sample value', ->

--- a/test/integration/compile-swagger-test.coffee
+++ b/test/integration/compile-swagger-test.coffee
@@ -19,8 +19,8 @@ describe('compile() · Swagger', ->
       )
     )
 
-    it('is compiled into expected number of transactions', ->
-      assert.equal(compilationResult.transactions.length, 0)
+    it('is compiled into zero transactions', ->
+      assert.deepEqual(compilationResult.transactions, [])
     )
     it('is compiled with no warnings', ->
       assert.deepEqual(compilationResult.warnings, [])

--- a/test/integration/compile-swagger-test.coffee
+++ b/test/integration/compile-swagger-test.coffee
@@ -10,63 +10,68 @@ describe('compile() · Swagger', ->
   locationSchema = createLocationSchema()
 
   describe('causing a \'not specified in URI Template\' error', ->
-    errors = undefined
-    transactions = undefined
+    compilationResult = undefined
 
     beforeEach((done) ->
-      compileFixture(fixtures.notSpecifiedInUriTemplateAnnotation.swagger, (err, compilationResult) ->
-        return done(err) if err
-        {errors, transactions} = compilationResult
-        done()
+      compileFixture(fixtures.notSpecifiedInUriTemplateAnnotation.swagger, (args...) ->
+        [err, compilationResult] = args
+        done(err)
       )
     )
 
     it('is compiled into expected number of transactions', ->
-      assert.equal(transactions.length, 0)
+      assert.equal(compilationResult.transactions.length, 0)
+    )
+    it('is compiled with no warnings', ->
+      assert.deepEqual(compilationResult.warnings, [])
     )
     it('is compiled with a single error', ->
-      assert.equal(errors.length, 1)
+      assert.equal(compilationResult.errors.length, 1)
     )
     context('the error', ->
       it('comes from parser', ->
-        assert.equal(errors[0].component, 'apiDescriptionParser')
+        assert.equal(compilationResult.errors[0].component, 'apiDescriptionParser')
       )
       it('has code', ->
-        assert.isNumber(errors[0].code)
+        assert.isNumber(compilationResult.errors[0].code)
       )
       it('has message', ->
-        assert.include(errors[0].message.toLowerCase(), 'no corresponding')
-        assert.include(errors[0].message.toLowerCase(), 'in the path string')
+        assert.include(compilationResult.errors[0].message.toLowerCase(), 'no corresponding')
+        assert.include(compilationResult.errors[0].message.toLowerCase(), 'in the path string')
       )
       it('has no location', ->
-        assert.notOk(errors[0].location)
+        assert.notOk(compilationResult.errors[0].location)
       )
       it('has no origin', ->
-        assert.isUndefined(errors[0].origin)
+        assert.isUndefined(compilationResult.errors[0].origin)
       )
     )
   )
 
   describe('with \'produces\'', ->
-    request = undefined
-    response = undefined
+    compilationResult = undefined
 
     beforeEach((done) ->
-      compileFixture(fixtures.produces.swagger, (err, compilationResult) ->
-        return done(err) if err
-        {request, response} = compilationResult.transactions[0]
-        done()
+      compileFixture(fixtures.produces.swagger, (args...) ->
+        [err, compilationResult] = args
+        done(err)
       )
     )
 
+    it('is compiled with no warnings', ->
+      assert.deepEqual(compilationResult.warnings, [])
+    )
+    it('is compiled with no errors', ->
+      assert.deepEqual(compilationResult.errors, [])
+    )
     context('compiles a transaction', ->
       it('with expected request headers', ->
-        assert.deepEqual(request.headers, {
+        assert.deepEqual(compilationResult.transactions[0].request.headers, {
           'Accept': {value: 'application/json'}
         })
       )
       it('with expected response headers', ->
-        assert.deepEqual(response.headers, {
+        assert.deepEqual(compilationResult.transactions[0].response.headers, {
           'Content-Type': {value: 'application/json'}
         })
       )
@@ -74,65 +79,71 @@ describe('compile() · Swagger', ->
   )
 
   describe('with \'consumes\'', ->
-    request = undefined
-    response = undefined
+    compilationResult = undefined
 
     beforeEach((done) ->
-      compileFixture(fixtures.consumes.swagger, (err, compilationResult) ->
-        return done(err) if err
-        {request, response} = compilationResult.transactions[0]
-        done()
+      compileFixture(fixtures.consumes.swagger, (args...) ->
+        [err, compilationResult] = args
+        done(err)
       )
     )
 
+    it('is compiled with no warnings', ->
+      assert.deepEqual(compilationResult.warnings, [])
+    )
+    it('is compiled with no errors', ->
+      assert.deepEqual(compilationResult.errors, [])
+    )
     context('compiles a transaction', ->
       it('with expected request headers', ->
-        assert.deepEqual(request.headers, {
+        assert.deepEqual(compilationResult.transactions[0].request.headers, {
           'Content-Type': {value: 'application/json'}
         })
       )
       it('with expected response headers', ->
-        assert.deepEqual(response.headers, {})
+        assert.deepEqual(compilationResult.transactions[0].response.headers, {})
       )
     )
   )
 
   describe('with multiple responses', ->
-    transactions = undefined
+    compilationResult = undefined
     filename = 'apiDescription.json'
     detectTransactionExampleNumbers = sinon.spy(require('../../src/detect-transaction-example-numbers'))
-
     expectedStatusCodes = [200, 400, 500]
 
     beforeEach((done) ->
       stubs = {'./detect-transaction-example-numbers': detectTransactionExampleNumbers}
-
       compileFixture(fixtures.multipleResponses.swagger, {filename, stubs}, (args...) ->
         [err, compilationResult] = args
-        transactions = compilationResult?.transactions
         done(err)
       )
     )
 
-    it('detection of transaction examples was not called', ->
+    it('does not call detection of transaction examples', ->
       assert.isFalse(detectTransactionExampleNumbers.called)
     )
-    it('expected number of transactions was returned', ->
-      assert.equal(transactions.length, expectedStatusCodes.length)
+    it('returns expected number of transactions', ->
+      assert.equal(compilationResult.transactions.length, expectedStatusCodes.length)
     )
-
+    it('is compiled with no warnings', ->
+      assert.deepEqual(compilationResult.warnings, [])
+    )
+    it('is compiled with no errors', ->
+      assert.deepEqual(compilationResult.errors, [])
+    )
     for statusCode, i in expectedStatusCodes
       do (statusCode, i) ->
         context("origin of transaction ##{i + 1}", ->
           it('uses URI as resource name', ->
-            assert.equal(transactions[i].origin.resourceName, '/honey')
+            assert.equal(compilationResult.transactions[i].origin.resourceName, '/honey')
           )
           it('uses method as action name', ->
-            assert.equal(transactions[i].origin.actionName, 'GET')
+            assert.equal(compilationResult.transactions[i].origin.actionName, 'GET')
           )
           it('uses status code and response\'s Content-Type as example name', ->
             assert.equal(
-              transactions[i].origin.exampleName,
+              compilationResult.transactions[i].origin.exampleName,
               "#{statusCode} > application/json"
             )
           )

--- a/test/integration/compile-test.coffee
+++ b/test/integration/compile-test.coffee
@@ -54,7 +54,7 @@ describe('compile() · all API description formats', ->
         assert.deepEqual(compilationResult.warnings, [])
       )
       it('is compiled with an error', ->
-        assert.ok(compilationResult.errors.length)
+        assert.equal(compilationResult.errors.length, 1)
       )
       context('the error', ->
         it('comes from parser', ->
@@ -95,6 +95,9 @@ describe('compile() · all API description formats', ->
 
       it('is compiled into zero transactions', ->
         assert.deepEqual(compilationResult.transactions, [])
+      )
+      it('is compiled with maximum one warning', ->
+        assert.isAtMost(compilationResult.warnings.length, 1)
       )
       it('is compiled with one error', ->
         assert.equal(compilationResult.errors.length, 1)
@@ -140,6 +143,21 @@ describe('compile() · all API description formats', ->
       it('is compiled into zero transactions', ->
         assert.deepEqual(compilationResult.transactions, [])
       )
+      it('is compiled with maximum two warnings', ->
+        assert.isAtMost(compilationResult.warnings.length, 2)
+      )
+      it('there is maximum one warning from parser', ->
+        warnings = compilationResult.warnings.filter((warning) ->
+          warning.component is 'apiDescriptionParser'
+        )
+        assert.isAtMost(warnings.length, 1)
+      )
+      it('there is one warning from URI expansion', ->
+        warnings = compilationResult.warnings.filter((warning) ->
+          warning.component is 'uriTemplateExpansion'
+        )
+        assert.equal(warnings.length, 1)
+      )
       it('is compiled with one error', ->
         assert.equal(compilationResult.errors.length, 1)
       )
@@ -177,24 +195,29 @@ describe('compile() · all API description formats', ->
       it('is compiled into expected number of transactions', ->
         assert.equal(compilationResult.transactions.length, 1)
       )
-      it('is compiled with warnings', ->
+      it('is compiled with some warnings', ->
         assert.ok(compilationResult.warnings.length)
       )
-      context('the warning', ->
+      context('the warnings', ->
         it('comes from parser', ->
-          assert.equal(compilationResult.warnings[0].component, 'apiDescriptionParser')
+          for warning in compilationResult.warnings
+            assert.equal(warning.component, 'apiDescriptionParser')
         )
-        it('has code', ->
-          assert.isNumber(compilationResult.warnings[0].code)
+        it('have code', ->
+          for warning in compilationResult.warnings
+            assert.isNumber(warning.code)
         )
-        it('has message', ->
-          assert.isString(compilationResult.warnings[0].message)
+        it('have message', ->
+          for warning in compilationResult.warnings
+            assert.isString(warning.message)
         )
-        it('has location', ->
-          assert.jsonSchema(compilationResult.warnings[0].location, locationSchema)
+        it('have location', ->
+          for warning in compilationResult.warnings
+            assert.jsonSchema(warning.location, locationSchema)
         )
-        it('has no origin', ->
-          assert.isUndefined(compilationResult.warnings[0].origin)
+        it('have no origin', ->
+          for warning in compilationResult.warnings
+            assert.isUndefined(warning.origin)
         )
       )
       it('is compiled with no errors', ->
@@ -232,24 +255,29 @@ describe('compile() · all API description formats', ->
       it('is compiled into some transactions', ->
         assert.ok(compilationResult.transactions.length)
       )
-      it('is compiled with warnings', ->
+      it('is compiled with some warnings', ->
         assert.ok(compilationResult.warnings.length)
       )
-      context('the warning', ->
-        it('comes from compiler', ->
-          assert.equal(compilationResult.warnings[0].component, 'uriTemplateExpansion')
+      context('the warnings', ->
+        it('come from compiler', ->
+          for warning in compilationResult.warnings
+            assert.equal(warning.component, 'uriTemplateExpansion')
         )
-        it('has no code', ->
-          assert.isUndefined(compilationResult.warnings[0].code)
+        it('have no code', ->
+          for warning in compilationResult.warnings
+            assert.isUndefined(warning.code)
         )
-        it('has message', ->
-          assert.include(compilationResult.warnings[0].message, message)
+        it('have message', ->
+          for warning in compilationResult.warnings
+            assert.include(warning.message, message)
         )
-        it('has no location', ->
-          assert.isUndefined(compilationResult.warnings[0].location)
+        it('have no location', ->
+          for warning in compilationResult.warnings
+            assert.isUndefined(warning.location)
         )
-        it('has origin', ->
-          assert.jsonSchema(compilationResult.warnings[0].origin, originSchema)
+        it('have origin', ->
+          for warning in compilationResult.warnings
+            assert.jsonSchema(warning.origin, originSchema)
         )
       )
       it('is compiled with no errors', ->
@@ -259,11 +287,14 @@ describe('compile() · all API description formats', ->
   )
 
   describe('causing an \'ambiguous parameters\' warning in URI expansion', ->
+    # Parsers may provide error in similar situations, however, we do not
+    # want to rely on them (implementations differ). This warning is returned
+    # in case parameters do not have any kind of value Dredd could use. Mind
+    # that situations when parser gives the error and when this warning is
+    # returned can differ and also the severity is different.
+    #
     # Special side effect of the warning is that affected transactions
     # should be skipped (shouldn't appear in output of the compilation).
-    #
-    # The API description documents used as fixtures to test this situation
-    # can also cause errors. We do not care about those in this test.
 
     fixtures.ambiguousParametersAnnotation.forEachDescribe(({source}) ->
       compilationResult = undefined
@@ -298,6 +329,9 @@ describe('compile() · all API description formats', ->
           assert.jsonSchema(compilationResult.warnings[0].origin, originSchema)
         )
       )
+      it('is compiled with maximum one error', ->
+        assert.isAtMost(compilationResult.errors.length, 1)
+      )
     )
   )
 
@@ -326,24 +360,29 @@ describe('compile() · all API description formats', ->
       it('is compiled into some transactions', ->
         assert.ok(compilationResult.transactions.length)
       )
-      it('is compiled with warnings', ->
+      it('is compiled with some warnings', ->
         assert.ok(compilationResult.warnings.length)
       )
-      context('the warning', ->
-        it('comes from compiler', ->
-          assert.equal(compilationResult.warnings[0].component, 'parametersValidation')
+      context('the warnings', ->
+        it('come from compiler', ->
+          for warning in compilationResult.warnings
+            assert.equal(warning.component, 'parametersValidation')
         )
-        it('has no code', ->
-          assert.isUndefined(compilationResult.warnings[0].code)
+        it('have no code', ->
+          for warning in compilationResult.warnings
+            assert.isUndefined(warning.code)
         )
-        it('has message', ->
-          assert.include(compilationResult.warnings[0].message, message)
+        it('have message', ->
+          for warning in compilationResult.warnings
+            assert.include(warning.message, message)
         )
-        it('has no location', ->
-          assert.isUndefined(compilationResult.warnings[0].location)
+        it('have no location', ->
+          for warning in compilationResult.warnings
+            assert.isUndefined(warning.location)
         )
-        it('has origin', ->
-          assert.jsonSchema(compilationResult.warnings[0].origin, originSchema)
+        it('have origin', ->
+          for warning in compilationResult.warnings
+            assert.jsonSchema(warning.origin, originSchema)
         )
       )
       it('is compiled with no errors', ->
@@ -417,6 +456,9 @@ describe('compile() · all API description formats', ->
 
       it('is compiled into one transaction', ->
         assert.equal(compilationResult.transactions.length, 1)
+      )
+      it('is compiled with maximum one warning', ->
+        assert.isAtMost(compilationResult.warnings.length, 1)
       )
       it('is compiled with one error', ->
         assert.equal(compilationResult.errors.length, 1)
@@ -558,30 +600,41 @@ describe('compile() · all API description formats', ->
       it('is compiled with no errors', ->
         assert.deepEqual(compilationResult.errors, [])
       )
-      it('is compiled with warnings', ->
-        assert.ok(compilationResult.warnings.length)
+      it('is compiled with maximum two warnings', ->
+        assert.isAtMost(compilationResult.warnings.length, 2)
       )
-      it('there are no other warnings than from parser or URI expansion', ->
-        assert.equal(compilationResult.warnings.filter((w) ->
-          w.component isnt 'uriTemplateExpansion' and
-          w.component isnt 'apiDescriptionParser'
-        ).length, 0)
+      it('there is maximum one warning from parser', ->
+        warnings = compilationResult.warnings.filter((warning) ->
+          warning.component is 'apiDescriptionParser'
+        )
+        assert.isAtMost(warnings.length, 1)
+      )
+      it('there is one warning from URI expansion', ->
+        warnings = compilationResult.warnings.filter((warning) ->
+          warning.component is 'uriTemplateExpansion'
+        )
+        assert.equal(warnings.length, 1)
       )
       context('the last warning', ->
         it('comes from URI expansion', ->
-          assert.equal(compilationResult.warnings[-1..][0].component, 'uriTemplateExpansion')
+          lastWarning = compilationResult.warnings[compilationResult.warnings.length - 1]
+          assert.equal(lastWarning.component, 'uriTemplateExpansion')
         )
         it('has no code', ->
-          assert.isUndefined(compilationResult.warnings[-1..][0].code)
+          lastWarning = compilationResult.warnings[compilationResult.warnings.length - 1]
+          assert.isUndefined(lastWarning.code)
         )
         it('has message', ->
-          assert.include(compilationResult.warnings[-1..][0].message.toLowerCase(), 'default value for a required parameter')
+          lastWarning = compilationResult.warnings[compilationResult.warnings.length - 1]
+          assert.include(lastWarning.message.toLowerCase(), 'default value for a required parameter')
         )
         it('has no location', ->
-          assert.isUndefined(compilationResult.warnings[-1..][0].location)
+          lastWarning = compilationResult.warnings[compilationResult.warnings.length - 1]
+          assert.isUndefined(lastWarning.location)
         )
         it('has origin', ->
-          assert.jsonSchema(compilationResult.warnings[-1..][0].origin, originSchema)
+          lastWarning = compilationResult.warnings[compilationResult.warnings.length - 1]
+          assert.jsonSchema(lastWarning.origin, originSchema)
         )
       )
     )

--- a/test/integration/compile-test.coffee
+++ b/test/integration/compile-test.coffee
@@ -444,7 +444,7 @@ describe('compile() · all API description formats', ->
     )
   )
 
-  describe.skip('with parameters having example values', ->
+  describe('with parameters having example values', ->
     fixtures.exampleParameters.forEachDescribe(({source}) ->
       compilationResult = undefined
 
@@ -455,15 +455,14 @@ describe('compile() · all API description formats', ->
         )
       )
 
-      it.skip('is compiled with no warnings', ->
-        # https://github.com/apiaryio/drafter/issues/500
+      it('is compiled with no warnings', ->
         assert.deepEqual(compilationResult.warnings, [])
       )
       it('is compiled with no errors', ->
         assert.deepEqual(compilationResult.errors, [])
       )
       it('expands the request URI with the example value', ->
-        assert.equal(compilationResult.transactions[0].request.uri, '/honey?beekeeper=Honza&flavour=sweet,spicy')
+        assert.equal(compilationResult.transactions[0].request.uri, '/honey?beekeeper=Honza&flavour=spicy')
       )
     )
   )

--- a/test/integration/compile-test.coffee
+++ b/test/integration/compile-test.coffee
@@ -96,14 +96,16 @@ describe('compile() · all API description formats', ->
       it('is compiled into zero transactions', ->
         assert.deepEqual(compilationResult.transactions, [])
       )
-      it('is compiled with maximum one warning', ->
+      it('is compiled with maximum one warning from parser', ->
         assert.isAtMost(compilationResult.warnings.length, 1)
+        if compilationResult.warnings.length
+          assert.equal(compilationResult.warnings[0].component, 'apiDescriptionParser')
       )
       it('is compiled with one error', ->
         assert.equal(compilationResult.errors.length, 1)
       )
       context('the error', ->
-        it('comes from compiler', ->
+        it('comes from URI expansion', ->
           assert.equal(compilationResult.errors[0].component, 'uriTemplateExpansion')
         )
         it('has no code', ->
@@ -122,7 +124,7 @@ describe('compile() · all API description formats', ->
     )
   )
 
-  describe('causing an error in URI validation', ->
+  describe('causing an error in URI parameters validation', ->
     # Parsers may provide warning in similar situations, however, we do not
     # want to rely on them (implementations differ). This error is returned
     # in case Dredd Transactions are not satisfied with the input for
@@ -162,7 +164,7 @@ describe('compile() · all API description formats', ->
         assert.equal(compilationResult.errors.length, 1)
       )
       context('the error', ->
-        it('comes from compiler', ->
+        it('comes from URI parameters validation', ->
           assert.equal(compilationResult.errors[0].component, 'parametersValidation')
         )
         it('has no code', ->
@@ -259,7 +261,7 @@ describe('compile() · all API description formats', ->
         assert.ok(compilationResult.warnings.length)
       )
       context('the warnings', ->
-        it('come from compiler', ->
+        it('come from URI expansion', ->
           for warning in compilationResult.warnings
             assert.equal(warning.component, 'uriTemplateExpansion')
         )
@@ -313,7 +315,7 @@ describe('compile() · all API description formats', ->
         assert.equal(compilationResult.warnings.length, 1)
       )
       context('the warning', ->
-        it('comes from compiler', ->
+        it('comes from URI expansion', ->
           assert.equal(compilationResult.warnings[0].component, 'uriTemplateExpansion')
         )
         it('has no code', ->
@@ -329,13 +331,14 @@ describe('compile() · all API description formats', ->
           assert.jsonSchema(compilationResult.warnings[0].origin, originSchema)
         )
       )
-      it('is compiled with maximum one error', ->
-        assert.isAtMost(compilationResult.errors.length, 1)
+      it('is compiled with one error from URI parameters validation', ->
+        assert.equal(compilationResult.errors.length, 1)
+        assert.equal(compilationResult.errors[0].component, 'parametersValidation')
       )
     )
   )
 
-  describe('causing a warning in URI validation', ->
+  describe('causing a warning in URI parameters validation', ->
     # Since 'validateParams' doesn't actually return any warnings
     # (but could in the future), we need to pretend it's possible for this
     # test.
@@ -364,7 +367,7 @@ describe('compile() · all API description formats', ->
         assert.ok(compilationResult.warnings.length)
       )
       context('the warnings', ->
-        it('come from compiler', ->
+        it('come from URI parameters validation', ->
           for warning in compilationResult.warnings
             assert.equal(warning.component, 'parametersValidation')
         )
@@ -457,14 +460,15 @@ describe('compile() · all API description formats', ->
       it('is compiled into one transaction', ->
         assert.equal(compilationResult.transactions.length, 1)
       )
-      it('is compiled with maximum one warning', ->
-        assert.isAtMost(compilationResult.warnings.length, 1)
+      it('is compiled with maximum one warning from parser', ->
+        if compilationResult.warnings.length
+          assert.equal(compilationResult.warnings[0].component, 'apiDescriptionParser')
       )
       it('is compiled with one error', ->
         assert.equal(compilationResult.errors.length, 1)
       )
       context('the error', ->
-        it('comes from compiler', ->
+        it('comes from URI parameters validation', ->
           assert.equal(compilationResult.errors[0].component, 'parametersValidation')
         )
         it('has no code', ->

--- a/test/integration/compile-test.coffee
+++ b/test/integration/compile-test.coffee
@@ -366,7 +366,7 @@ describe('compile() · all API description formats', ->
       it('is compiled with no warnings', ->
         assert.deepEqual(compilationResult.warnings, [])
       )
-      it.skip('is compiled with no errors', ->
+      it('is compiled with no errors', ->
         assert.deepEqual(compilationResult.errors, [])
       )
       it('expands the request URI with the first enum value', ->
@@ -389,7 +389,7 @@ describe('compile() · all API description formats', ->
       it('is compiled with no warnings', ->
         assert.deepEqual(compilationResult.warnings, [])
       )
-      it.skip('is compiled with no errors', ->
+      it('is compiled with no errors', ->
         assert.deepEqual(compilationResult.errors, [])
       )
       it('expands the request URI with the example value', ->
@@ -415,8 +415,8 @@ describe('compile() · all API description formats', ->
         )
       )
 
-      it.skip('is compiled into zero transactions', ->
-        assert.deepEqual(compilationResult.transactions, [])
+      it('is compiled into one transaction', ->
+        assert.equal(compilationResult.transactions.length, 1)
       )
       it('is compiled with one error', ->
         assert.equal(compilationResult.errors.length, 1)
@@ -438,10 +438,13 @@ describe('compile() · all API description formats', ->
           assert.jsonSchema(compilationResult.errors[0].origin, originSchema)
         )
       )
+      it('expands the request URI with the example value', ->
+        assert.equal(compilationResult.transactions[0].request.uri, '/honey?beekeeper=Pavan')
+      )
     )
   )
 
-  describe('with parameters having example values', ->
+  describe.skip('with parameters having example values', ->
     fixtures.exampleParameters.forEachDescribe(({source}) ->
       compilationResult = undefined
 
@@ -456,10 +459,10 @@ describe('compile() · all API description formats', ->
         # https://github.com/apiaryio/drafter/issues/500
         assert.deepEqual(compilationResult.warnings, [])
       )
-      it.skip('is compiled with no errors', ->
+      it('is compiled with no errors', ->
         assert.deepEqual(compilationResult.errors, [])
       )
-      it.skip('expands the request URI with the example value', ->
+      it('expands the request URI with the example value', ->
         assert.equal(compilationResult.transactions[0].request.uri, '/honey?beekeeper=Honza&flavour=sweet,spicy')
       )
     )
@@ -530,7 +533,7 @@ describe('compile() · all API description formats', ->
       it('is compiled with no warnings', ->
         assert.deepEqual(compilationResult.warnings, [])
       )
-      it.skip('is compiled with no errors', ->
+      it('is compiled with no errors', ->
         assert.deepEqual(compilationResult.errors, [])
       )
       it('expands the request URI using the default value', ->

--- a/test/unit/compile-uri/validate-parameters-test.coffee
+++ b/test/unit/compile-uri/validate-parameters-test.coffee
@@ -100,11 +100,7 @@ describe 'validateParams', ->
           required: true
           example: 'D'
           default: ''
-          values: [
-            { "value": "A" },
-            { "value": "B" },
-            { "value": "C" }
-          ]
+          values: ['A', 'B', 'C']
 
       result = validateParams params
       message = result['errors'][0]
@@ -120,11 +116,7 @@ describe 'validateParams', ->
           required: true
           example: 'A'
           default: ''
-          values: [
-            { "value": "A" },
-            { "value": "B" },
-            { "value": "C" }
-          ]
+          values: ['A', 'B', 'C']
 
       result = validateParams params
       assert.equal result['errors'].length, 0


### PR DESCRIPTION
This is a PR fixes various regressions (such as https://github.com/apiaryio/dredd/issues/872) caused by https://github.com/apiaryio/dredd-transactions/pull/94 and maybe also other recent changes and dependency upgrades.

I recommend going commit-by-commit during the review 🔍 Changes broken down to commits:

- 8564317 - Refactors integration tests and adds checks for extraneous warnings and errors (which fail, many times). Also adds several new failing tests. All failing tests are `.skip()`-ped in the commit.
- 53cb74d - Refactors integration tests specific to Swagger and API Blueprint the same way as previous commit. Adds checks for extraneous warnings and errors.
- 10e3700 - Fixes the problem which is causing https://github.com/apiaryio/dredd/issues/872. See commit message for a detailed description of what was the issue.
- 73a0d2a - Quite self-explaining.
- e47bc4d - Removes array URI parameters from the tests. See re-opening of https://github.com/apiaryio/dredd/issues/791#issuecomment-324022366, which declares them an experimental and untested feature for now.

Merging this should result in automatic release of a patch version of Dredd Transactions, which should fix the https://github.com/apiaryio/dredd/issues/872 the same way as it was introduced.