### PR TITLE
Add support for multiple HTTP headers of the same name

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,11 +99,17 @@ Represents a single *HTTP Transaction* (Request-Response pair) and its location 
 - request (object) - HTTP Request as described in API description document.
     - method
     - uri: `/message` (string) - Informative URI of the Request.
-    - headers (object)
+    - headers (array) - List of HTTP headers in their original order, with the original casing of the header name, including multiple headers of the same name.
+        - (object)
+            - name: `Content-Type` (string)
+            - value: `text/plain` (string)
     - body: `Hello world!\n` (string)
 - response (object) - Expected HTTP Response as described in API description document.
     - status: `200` (string)
-    - headers (object)
+    - headers (array) - List of HTTP headers in their original order, with the original casing of the header name, including multiple headers of the same name.
+        - (object)
+            - name: `Content-Type` (string)
+            - value: `text/plain` (string)
     - body (string)
     - schema (string)
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "url": "https://github.com/apiaryio/dredd-transactions"
   },
   "dependencies": {
-    "caseless": "^0.12.0",
     "clone": "^2.1.1",
     "fury": "^3.0.0-beta.4",
     "fury-adapter-apib-parser": "^0.9.0",

--- a/src/compile.coffee
+++ b/src/compile.coffee
@@ -150,8 +150,7 @@ compileOriginExampleName = (mediaType, httpResponseElement, exampleNo) ->
 
     contentType = headers
       .filter((header) -> header.name.toLowerCase() is 'content-type')
-      .map((header) -> header.value)
-      .join(', ')
+      .map((header) -> header.value)[0]
 
     segments = []
     segments.push(statusCode) if statusCode

--- a/src/compile.coffee
+++ b/src/compile.coffee
@@ -1,5 +1,4 @@
 clone = require('clone')
-caseless = require('caseless')
 
 detectTransactionExampleNumbers = require('./detect-transaction-example-numbers')
 compileUri = require('./compile-uri')
@@ -148,7 +147,11 @@ compileOriginExampleName = (mediaType, httpResponseElement, exampleNo) ->
   else
     statusCode = httpResponseElement.statusCode.toValue()
     headers = compileHeaders(httpResponseElement.headers)
-    contentType = caseless(headers).get('content-type')?.value
+
+    contentType = headers
+      .filter((header) -> header.name.toLowerCase() is 'content-type')
+      .map((header) -> header.value)
+      .join(', ')
 
     segments = []
     segments.push(statusCode) if statusCode
@@ -174,11 +177,10 @@ compilePathOrigin = (filename, httpTransactionElement, exampleNo) ->
 
 
 compileHeaders = (httpHeadersElement) ->
-  return {} unless httpHeadersElement
-  httpHeadersElement.toValue().reduce((headers, {key, value}) ->
-    headers[key] = {value}
-    return headers
-  , {})
+  return [] unless httpHeadersElement
+  return httpHeadersElement.toValue().map(({key, value}) ->
+    return {name: key, value}
+  )
 
 
 module.exports = compile

--- a/test/fixtures/api-blueprint/http-headers-multiple.apib
+++ b/test/fixtures/api-blueprint/http-headers-multiple.apib
@@ -1,0 +1,25 @@
+FORMAT: 1A
+
+# Beehive API
+
+# Honey [/honey]
+
+## Retrieve Honey [GET]
+
++ Request (application/json)
+
+    + Headers
+
+            X-Multiple: foo
+            X-Multiple: bar
+
++ Response 200 (application/json)
+
+    + Headers
+
+            Set-Cookie: session-id=123
+            Set-Cookie: likes-honey=true
+
+    + Body
+
+            {}

--- a/test/fixtures/index.coffee
+++ b/test/fixtures/index.coffee
@@ -150,6 +150,9 @@ fixtures =
   preferSample: fixture(
     apiBlueprint: fromFile('./api-blueprint/prefer-sample.apib')
   )
+  httpHeadersMultiple: fixture(
+    apiBlueprint: fromFile('./api-blueprint/http-headers-multiple.apib')
+  )
 
   # Specific to Swagger
   produces: fixture(

--- a/test/integration/compile-api-blueprint-test.coffee
+++ b/test/integration/compile-api-blueprint-test.coffee
@@ -130,8 +130,7 @@ describe('compile() · API Blueprint', ->
             headers = compilationResult.transactions[i].request.headers
             contentType = headers
               .filter((header) -> header.name is 'Content-Type')
-              .map((header) -> header.value)
-              .join(', ')
+              .map((header) -> header.value)[0]
             assert.equal(contentType, requestContentType)
           )
           it("has response with status code #{responseStatusCode}", ->

--- a/test/integration/compile-swagger-test.coffee
+++ b/test/integration/compile-swagger-test.coffee
@@ -66,14 +66,14 @@ describe('compile() · Swagger', ->
     )
     context('compiles a transaction', ->
       it('with expected request headers', ->
-        assert.deepEqual(compilationResult.transactions[0].request.headers, {
-          'Accept': {value: 'application/json'}
-        })
+        assert.deepEqual(compilationResult.transactions[0].request.headers, [
+          {name: 'Accept', value: 'application/json'}
+        ])
       )
       it('with expected response headers', ->
-        assert.deepEqual(compilationResult.transactions[0].response.headers, {
-          'Content-Type': {value: 'application/json'}
-        })
+        assert.deepEqual(compilationResult.transactions[0].response.headers, [
+          {name: 'Content-Type', value: 'application/json'}
+        ])
       )
     )
   )
@@ -96,12 +96,12 @@ describe('compile() · Swagger', ->
     )
     context('compiles a transaction', ->
       it('with expected request headers', ->
-        assert.deepEqual(compilationResult.transactions[0].request.headers, {
-          'Content-Type': {value: 'application/json'}
-        })
+        assert.deepEqual(compilationResult.transactions[0].request.headers, [
+          {name: 'Content-Type', value: 'application/json'}
+        ])
       )
       it('with expected response headers', ->
-        assert.deepEqual(compilationResult.transactions[0].response.headers, {})
+        assert.deepEqual(compilationResult.transactions[0].response.headers, [])
       )
     )
   )

--- a/test/integration/compile-test.coffee
+++ b/test/integration/compile-test.coffee
@@ -661,16 +661,16 @@ describe('compile() · all API description formats', ->
       )
       context('compiles a transaction', ->
         it('with expected request headers', ->
-          assert.deepEqual(compilationResult.transactions[0].request.headers, {
-            'Content-Type': {value: 'application/json'}
-            'Accept': {value: 'application/json'}
-          })
+          assert.deepEqual(compilationResult.transactions[0].request.headers, [
+            {name: 'Content-Type', value: 'application/json'}
+            {name: 'Accept', value: 'application/json'}
+          ])
         )
         it('with expected response headers', ->
-          assert.deepEqual(compilationResult.transactions[0].response.headers, {
-            'Content-Type': {value: 'application/json'}
-            'X-Test': {value: 'Adam'}
-          })
+          assert.deepEqual(compilationResult.transactions[0].response.headers, [
+            {name: 'Content-Type', value: 'application/json'}
+            {name: 'X-Test', value: 'Adam'}
+          ])
         )
       )
     )

--- a/test/schemas/compilation-result.coffee
+++ b/test/schemas/compilation-result.coffee
@@ -29,18 +29,20 @@ module.exports = (options = {}) ->
   # will default to true (= structure must contain transaction names and paths)
   paths = if options.paths is false then false else true
 
+  headersSchema =
+    type: 'array'
+    items:
+      type: 'object'
+      properties:
+        name: {type: 'string'}
+        value: {type: 'string'}
+
   requestSchema =
     type: 'object'
     properties:
       uri: {type: 'string', pattern: '^/'}
       method: {type: 'string'}
-      headers:
-        type: 'object'
-        patternProperties:
-          '': # property of any name
-            type: 'object'
-            properties:
-              value: {type: 'string'}
+      headers: headersSchema
       body: {type: 'string'}
     required: ['uri', 'method', 'headers']
     additionalProperties: false
@@ -49,13 +51,7 @@ module.exports = (options = {}) ->
     type: 'object'
     properties:
       status: {type: 'string'}
-      headers:
-        type: 'object'
-        patternProperties:
-          '': # property of any name
-            type: 'object'
-            properties:
-              value: {type: 'string'}
+      headers: headersSchema
       body: {type: 'string'}
     required: ['status', 'headers', 'body']
     additionalProperties: false


### PR DESCRIPTION
Close https://github.com/apiaryio/dredd-transactions/issues/9
Related to https://github.com/apiaryio/dredd/issues/356
Related to https://github.com/apiaryio/fury-adapter-swagger/issues/129

### BREAKING CHANGE

This changes the structure of Dredd Transactions' output.
Previously, the request and response headers would be provided as an object

    {'Content-Type': {'value': 'application/json'}, ...}

This is now array

    [{'name': 'Content-Type', 'value': 'application/json'}, ...]

-----

There will be multiple breaking changes. I created `honzajavorek/breaking-changes` branch, which will contain them and once they're all there and reviewed, the branch can be merged into `master`. Thanks to this we should get just one major version bump using the Semantic Release.

This PR is to the `honzajavorek/breaking-changes` branch.