### PR TITLE
Update fury-adapter-swagger to 0.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "clone": "^2.1.1",
     "fury": "^3.0.0-beta.4",
     "fury-adapter-apib-parser": "^0.9.0",
-    "fury-adapter-swagger": "^0.13.3",
+    "fury-adapter-swagger": "^0.14.2",
     "uri-template": "^1.0.0"
   },
   "devDependencies": {

--- a/test/integration/compile-swagger-test.coffee
+++ b/test/integration/compile-swagger-test.coffee
@@ -110,7 +110,7 @@ describe('compile() · Swagger', ->
     compilationResult = undefined
     filename = 'apiDescription.json'
     detectTransactionExampleNumbers = sinon.spy(require('../../src/detect-transaction-example-numbers'))
-    expectedStatusCodes = [200, 400, 500]
+    expectedStatusCodes = [200, 200, 400, 400, 500, 500]
 
     beforeEach((done) ->
       stubs = {'./detect-transaction-example-numbers': detectTransactionExampleNumbers}
@@ -132,19 +132,23 @@ describe('compile() · Swagger', ->
     it('is compiled with no errors', ->
       assert.deepEqual(compilationResult.errors, [])
     )
+
     for statusCode, i in expectedStatusCodes
       do (statusCode, i) ->
         context("origin of transaction ##{i + 1}", ->
           it('uses URI as resource name', ->
             assert.equal(compilationResult.transactions[i].origin.resourceName, '/honey')
           )
+
           it('uses method as action name', ->
             assert.equal(compilationResult.transactions[i].origin.actionName, 'GET')
           )
+
           it('uses status code and response\'s Content-Type as example name', ->
+            contentType = if i % 2 then 'application/json' else 'application/xml'
             assert.equal(
               compilationResult.transactions[i].origin.exampleName,
-              "#{statusCode} > application/json"
+              "#{statusCode} > #{contentType}"
             )
           )
         )


### PR DESCRIPTION
There were some significant changes to how request/responses are created in the Swagger adapter. Previously Swagger adapter would drop all permutations and only show JSON based types or `application/x-www-form-urlencoded` (for requests).

Now when a user has multiple produces/consumes all permutations will be generated as request/response pairs.

For example, given the Swagger document below which consumes `application/json`, `multipart/form-data` and `application/x-www-form-urlencoded` and produces both `application/json ` and `application/xml `.

```yaml
swagger: '2.0'
info:
  title: example
  version: "1.0.0"
consumes:
  - application/json
  - multipart/form-data
  - application/x-www-form-urlencoded
produces:
  - application/json
  - application/xml
paths:
  '/test':
    post:
      parameters:
        - name: name
          in: formData
          required: true
          type: string
      responses:
        200:
          description: 'My Response'
          examples:
            application/xml:
              <myxml>heyyy</myxml>
```

In a previous version of the Swagger adapter, this would generate a single request/response pair which mixed various pieces of data. Which would be somewhat similar to the following API Blueprint:

```
+ Request (application/x-www-form-urlencoded)
    + Attributes
        + name (string)

    + Body

            name=eu%20

+ Response 200 (application/json)

        <myxml>heyyy</myxml>
```

Obviously this is incorrect, we have an XML example returned from `application/json` and we dropped two out of three request.

After the updated parser, this would produce a request/response pair for every permutation.