### PR TITLE
Upgrade dependencies (& more)

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,0 +1,3 @@
+{
+    "extends": ["@commitlint/config-angular"]
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: "node_js"
 node_js:
   - "4"
   - "6"
+  - "8"
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,7 @@ cache:
   directories:
     - "node_modules"
 before_install:
-  # Travis CI has only shallow clone of the repository. We need to get the 'master' branch
-  # so 'conventional-changelog-lint' could compare commits and lint them: marionebl/conventional-changelog-lint#7
-  - "git remote set-branches origin master && git fetch && git checkout master && git checkout -"
+  - "git fetch --unshallow"  # for commitlint to work
   - "npm -g install npm@latest"
 install: "if [[ $DRAFTER = JS ]]; then npm install --no-optional; else npm install; fi"
 script:

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "mocha-lcov-reporter": "^1.3.0",
     "proxyquire": "^1.8.0",
     "semantic-release": "^7.0.2",
-    "sinon": "^2.2.0",
+    "sinon": "^4.0.1",
     "swagger-zoo": "^2.5.2"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "cz-conventional-changelog": "^2.0.0",
     "drafter": "^1.0.0",
     "jscoverage": "^0.6.0",
-    "mocha": "^3.4.1",
+    "mocha": "^4.0.1",
     "mocha-lcov-reporter": "^1.3.0",
     "proxyquire": "^1.8.0",
     "semantic-release": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "mocha": "^4.0.1",
     "mocha-lcov-reporter": "^1.3.0",
     "proxyquire": "^1.8.0",
-    "semantic-release": "^7.0.2",
+    "semantic-release": "^8.2.0",
     "sinon": "^4.0.1",
     "swagger-zoo": "^2.5.2"
   },

--- a/package.json
+++ b/package.json
@@ -37,14 +37,12 @@
     "coveralls": "^2.13.1",
     "cz-conventional-changelog": "^2.0.0",
     "drafter": "^1.0.0",
-    "jscoverage": "^0.6.0",
     "mocha": "^4.0.1",
     "mocha-lcov-reporter": "^1.3.0",
     "proxyquire": "^1.8.0",
     "semantic-release": "^7.0.2",
     "sinon": "^2.2.0",
-    "swagger-zoo": "^2.5.2",
-    "tv4": "^1.3.0"
+    "swagger-zoo": "^2.5.2"
   },
   "keywords": [
     "api",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": ">= 4"
   },
   "scripts": {
-    "lint": "conventional-changelog-lint --from=master && coffeelint src",
+    "lint": "scripts/commitlint.sh && coffeelint src",
     "build": "coffee -b -c -o lib/ src/",
     "test": "mocha \"test/**/*-test.coffee\"",
     "test:coverage": "scripts/coverage.sh",
@@ -28,6 +28,8 @@
     "uri-template": "^1.0.0"
   },
   "devDependencies": {
+    "@commitlint/cli": "^4.2.1",
+    "@commitlint/config-angular": "^4.2.1",
     "chai": "^4.1.0",
     "chai-json-schema": "^1.3.0",
     "coffee-coverage": "^2.0.1",
@@ -35,7 +37,6 @@
     "coffeelint": "^1.15.7",
     "conventional-changelog-lint": "^1.1.9",
     "coveralls": "^2.13.1",
-    "cz-conventional-changelog": "^2.0.0",
     "drafter": "^1.0.0",
     "mocha": "^4.0.1",
     "mocha-lcov-reporter": "^1.3.0",
@@ -53,10 +54,5 @@
     "acceptance"
   ],
   "author": "Apiary Czech Republic, s.r.o. <support@apiary.io>",
-  "license": "MIT",
-  "config": {
-    "commitizen": {
-      "path": "./node_modules/cz-conventional-changelog"
-    }
-  }
+  "license": "MIT"
 }

--- a/scripts/commitlint.sh
+++ b/scripts/commitlint.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Validates format of the commit messages on Travis CI
+
+# Copyright (c) 2016 Mario Nebl
+# License: MIT (https://github.com/marionebl/commitlint/blob/master/license.md)
+# Source: https://marionebl.github.io/commitlint/#/guides-ci-setup
+
+set -e
+set -u
+
+
+if [[ $TRAVIS_PULL_REQUEST_SLUG != "" && $TRAVIS_PULL_REQUEST_SLUG != $TRAVIS_REPO_SLUG ]]; then
+    # This is a Pull Request from a different slug, hence a forked repository
+    git remote add "$TRAVIS_PULL_REQUEST_SLUG" "https://github.com/$TRAVIS_PULL_REQUEST_SLUG.git"
+    git fetch "$TRAVIS_PULL_REQUEST_SLUG"
+
+    # Use the fetched remote pointing to the source clone for comparison
+    TO="$TRAVIS_PULL_REQUEST_SLUG/$TRAVIS_PULL_REQUEST_BRANCH"
+else
+    # This is a Pull Request from the same remote, no clone repository
+    TO=$TRAVIS_COMMIT
+fi
+
+# Lint all commits in the PR
+# - Covers fork pull requests (when TO=slug/branch)
+# - Covers branch pull requests (when TO=branch)
+./node_modules/.bin/commitlint --from="$TRAVIS_BRANCH" --to="$TO"
+
+# Always lint the triggerig commit
+# - Covers direct commits
+./node_modules/.bin/commitlint --from="$TRAVIS_COMMIT"

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,4 @@
---compilers=coffee:coffee-script/register
+--require=coffee-script/register
 --reporter=test/reporter.js
+--watch-extensions=coffee
 --recursive

--- a/test/utils.coffee
+++ b/test/utils.coffee
@@ -1,9 +1,6 @@
-
 chai = require('chai')
 chai.use(require('chai-json-schema'))
-
 proxyquire = require('proxyquire').noPreserveCache()
-tv4 = require('tv4')
 
 parse = require('../src/parse')
 


### PR DESCRIPTION
- Upgrading several dependencies
- Removing some unnecessary dependencies
- Adding Node 8 to the Matrix - mainly out of curiosity, it's not official LTS yet
- Replacing the previous commit linter with the shiny new `commitlint` tool

Unfortunately, there is no way to simplify the Travis CI setup for commitlint. If this setup works, I think it could be worth to make the thing more reusable - https://github.com/marionebl/commitlint/issues/99