### PR TITLE
Use 'annotations' instead of 'errors' & 'warnings'

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,7 @@ Result of compilation. Alongside compiled [Transaction][transaction-object-spec]
 
 - `mediaType`: `text/vnd.apiblueprint` (string, default, nullable) - Media type of the input format, defaults to API Blueprint format. Can be empty in case of some fatal errors.
 - `transactions` (array[[Transaction][transaction-object-spec]]) - Compiled _HTTP Transactions_.
-- `errors` (array[[Annotation][annotation-object-spec]]) - Errors which occurred during parsing of the API description or during compilation of transactions.
-- `warnings` (array[[Annotation][annotation-object-spec]]) - Warnings which occurred during parsing of the API description or during compilation of transactions.
+- `annotations` (array[[Annotation][annotation-object-spec]]) - Errors and warnings which occurred during parsing of the API description or during compilation of transactions.
 
 <a name="transaction-object"></a>
 ### Transaction (object)
@@ -130,11 +129,13 @@ Description of an error or warning which occurred during parsing of the API desc
 
 #### Properties
 
+- type (enum[string])
+    - `error`
+    - `warning`
 - component (enum[string]) - In which component of the compilation process the annotation occurred.
     - `apiDescriptionParser`
     - `parametersValidation`
     - `uriTemplateExpansion`
-- code (number) - Parser-specific code of the annotation.
 - message (string) - Textual annotation. This is – in most cases – a human-readable message to be displayed to user.
 - location (array) - Locations of the annotation in the source file. A series of character-blocks, which may be non-continuous. For further details refer to API Elements' [Source Map](source-map) element.
     - (array, fixed) - Continuous characters block. A pair of character index and character count.

--- a/src/compile-uri/index.coffee
+++ b/src/compile-uri/index.coffee
@@ -4,7 +4,7 @@ expandUriTemplate = require('./expand-uri-template')
 
 
 module.exports = (httpRequestElement) ->
-  annotations = {errors: [], warnings: []}
+  annotations = []
   cascade = [
     httpRequestElement.parents.find('resource')
     httpRequestElement.parents.find('transition')
@@ -28,16 +28,16 @@ module.exports = (httpRequestElement) ->
   result = validateParams(params)
   component = 'parametersValidation'
   for error in result.errors
-    annotations.errors.push({component, message: error})
+    annotations.push({type: 'error', component, message: error})
   for warning in result.warnings
-    annotations.warnings.push({component, message: warning})
+    annotations.push({type: 'warning', component, message: warning})
 
   result = expandUriTemplate(href, params)
   component = 'uriTemplateExpansion'
   for error in result.errors
-    annotations.errors.push({component, message: error})
+    annotations.push({type: 'error', component, message: error})
   for warning in result.warnings
-    annotations.warnings.push({component, message: warning})
+    annotations.push({type: 'warning', component, message: warning})
 
   {uri: result.uri, annotations}
 

--- a/src/compile.coffee
+++ b/src/compile.coffee
@@ -11,24 +11,22 @@ compile = (mediaType, apiElements, filename) ->
   apiElements.freeze()
 
   transactions = []
-  errors = apiElements.errors.map(compileAnnotation)
-  warnings = apiElements.warnings.map(compileAnnotation)
+  annotations = apiElements.annotations.map(compileAnnotation)
 
   for {httpTransactionElement, exampleNo} in findRelevantTransactions(mediaType, apiElements)
-    {transaction, annotations} = compileTransaction(mediaType, filename, httpTransactionElement, exampleNo)
-    transactions.push(transaction) if transaction
-    errors = errors.concat(annotations.errors)
-    warnings = warnings.concat(annotations.warnings)
+    result = compileTransaction(mediaType, filename, httpTransactionElement, exampleNo)
+    transactions.push(result.transaction) if result.transaction
+    annotations = annotations.concat(result.annotations)
 
-  {mediaType, transactions, errors, warnings}
+  {mediaType, transactions, annotations}
 
 
 compileAnnotation = (annotationElement) ->
   {
+    type: annotationElement.classes.getValue(0)
     component: 'apiDescriptionParser'
-    code: annotationElement.code?.toValue()
     message: annotationElement.toValue()
-    location: annotationElement.sourceMapValue
+    location: annotationElement.sourceMapValue or [[0, 1]]
   }
 
 
@@ -73,7 +71,7 @@ compileTransaction = (mediaType, filename, httpTransactionElement, exampleNo) ->
   origin = compileOrigin(mediaType, filename, httpTransactionElement, exampleNo)
   {request, annotations} = compileRequest(httpTransactionElement.request)
 
-  [].concat(annotations.errors, annotations.warnings).forEach((annotation) ->
+  annotations.forEach((annotation) ->
     annotation.origin = clone(origin)
   )
   return {transaction: null, annotations} unless request
@@ -90,7 +88,7 @@ compileTransaction = (mediaType, filename, httpTransactionElement, exampleNo) ->
 compileRequest = (httpRequestElement) ->
   {uri, annotations} = compileUri(httpRequestElement)
 
-  [].concat(annotations.errors, annotations.warnings).forEach((annotation) ->
+  annotations.forEach((annotation) ->
     annotation.location = (
       httpRequestElement.href?.sourceMapValue or
       httpRequestElement.parents.find('transition').href?.sourceMapValue or

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -3,7 +3,7 @@ compileFromApiElements = require('./compile')
 
 
 compile = (source, filename, callback) ->
-  # All regular parser-related or compilation-related errors and warnings
+  # All regular parser-related or compilation-related annotations
   # should be returned in the "compilation result". Callback should get
   # an error only in case of unexpected crash.
 
@@ -34,8 +34,7 @@ createParserErrorCompilationResult = (message) ->
   return {
     mediaType: null
     transactions: []
-    warnings: []
-    errors: [{component: 'apiDescriptionParser', message}]
+    annotations: [{type: 'error', component: 'apiDescriptionParser', message, location: [[0, 1]]}]
   }
 
 

--- a/src/parse.coffee
+++ b/src/parse.coffee
@@ -36,6 +36,9 @@ parse = (source, callback) ->
 createWarning = (message) ->
   annotationElement = new fury.minim.elements.Annotation(message)
   annotationElement.classes.push('warning')
+  annotationElement.attributes.set('sourceMap', [
+    new fury.minim.elements.SourceMap([[0, 1]]),
+  ])
   return annotationElement
 
 

--- a/test/fixtures/api-blueprint/response-schema.apib
+++ b/test/fixtures/api-blueprint/response-schema.apib
@@ -4,15 +4,24 @@ FORMAT: 1A
 
 ## Honey [/honey]
 
-### Remove [DELETE]
+### With Body [POST]
 
 + Request (application/json)
 
-+ Response 200
++ Response 201
     + Body
 
             []
 
+    + Schema
+
+            {"type": "array"}
+
+### Without Body [DELETE]
+
++ Request (application/json)
+
++ Response 200
     + Schema
 
             {"type": "array"}

--- a/test/fixtures/swagger/consumes.yml
+++ b/test/fixtures/swagger/consumes.yml
@@ -4,9 +4,19 @@ info:
   title: Beehive API
 consumes:
   - application/json
+  - application/xml
 paths:
   /honey:
     get:
+      responses:
+        200:
+          description: pet response
+          schema:
+            $ref: '#/definitions/Bee'
+  /honey-with-override:
+    get:
+      consumes:
+        - application/json
       responses:
         200:
           description: pet response

--- a/test/integration/compile-swagger-test.coffee
+++ b/test/integration/compile-swagger-test.coffee
@@ -16,31 +16,22 @@ describe('compile() · Swagger', ->
       )
     )
 
-    it('is compiled into zero transactions', ->
-      assert.deepEqual(compilationResult.transactions, [])
+    it('produces one annotation and no transaction', ->
+      assert.jsonSchema(compilationResult, createCompilationResultSchema(
+        annotations: 1
+        transactions: 0
+      ))
     )
-    it('is compiled with no warnings', ->
-      assert.deepEqual(compilationResult.warnings, [])
-    )
-    it('is compiled with a single error', ->
-      assert.equal(compilationResult.errors.length, 1)
-    )
-    context('the error', ->
-      it('comes from parser', ->
-        assert.equal(compilationResult.errors[0].component, 'apiDescriptionParser')
+    context('the annotation', ->
+      it('is error', ->
+        assert.equal(compilationResult.annotations[0].type, 'error')
       )
-      it('has code', ->
-        assert.isNumber(compilationResult.errors[0].code)
+      it('comes from the parser', ->
+        assert.equal(compilationResult.annotations[0].component, 'apiDescriptionParser')
       )
       it('has message', ->
-        assert.include(compilationResult.errors[0].message.toLowerCase(), 'no corresponding')
-        assert.include(compilationResult.errors[0].message.toLowerCase(), 'in the path string')
-      )
-      it('has no location', ->
-        assert.isUndefined(compilationResult.errors[0].location)
-      )
-      it('has no origin', ->
-        assert.isUndefined(compilationResult.errors[0].origin)
+        assert.include(compilationResult.annotations[0].message.toLowerCase(), 'no corresponding')
+        assert.include(compilationResult.annotations[0].message.toLowerCase(), 'in the path string')
       )
     )
   )
@@ -55,22 +46,28 @@ describe('compile() · Swagger', ->
       )
     )
 
-    it('is compiled with no warnings', ->
-      assert.deepEqual(compilationResult.warnings, [])
+    it('produces no annotations and two transactions', ->
+      assert.jsonSchema(compilationResult, createCompilationResultSchema(
+        annotations: 0
+        transactions: 3
+      ))
     )
-    it('is compiled with no errors', ->
-      assert.deepEqual(compilationResult.errors, [])
-    )
-    context('compiles a transaction', ->
-      it('with expected request headers', ->
-        assert.deepEqual(compilationResult.transactions[0].request.headers, {
-          'Accept': {value: 'application/json'}
-        })
-      )
-      it('with expected response headers', ->
-        assert.deepEqual(compilationResult.transactions[0].response.headers, {
-          'Content-Type': {value: 'application/json'}
-        })
+    [
+      {accept: 'application/json', contentType: 'application/json'}
+      {accept: 'application/xml', contentType: 'application/xml'}
+      {accept: 'application/json', contentType: 'text/plain'}
+    ].forEach(({accept, contentType}, i) ->
+      context("compiles a transaction for the '#{contentType}' media type", ->
+        it('with expected request headers', ->
+          assert.deepEqual(compilationResult.transactions[i].request.headers, {
+            'Accept': {value: accept}
+          })
+        )
+        it('with expected response headers', ->
+          assert.deepEqual(compilationResult.transactions[i].response.headers, {
+            'Content-Type': {value: contentType}
+          })
+        )
       )
     )
   )
@@ -85,20 +82,26 @@ describe('compile() · Swagger', ->
       )
     )
 
-    it('is compiled with no warnings', ->
-      assert.deepEqual(compilationResult.warnings, [])
+    it('produces no annotations and three transactions', ->
+      assert.jsonSchema(compilationResult, createCompilationResultSchema(
+        annotations: 0
+        transactions: 3
+      ))
     )
-    it('is compiled with no errors', ->
-      assert.deepEqual(compilationResult.errors, [])
-    )
-    context('compiles a transaction', ->
-      it('with expected request headers', ->
-        assert.deepEqual(compilationResult.transactions[0].request.headers, {
-          'Content-Type': {value: 'application/json'}
-        })
-      )
-      it('with expected response headers', ->
-        assert.deepEqual(compilationResult.transactions[0].response.headers, {})
+    [
+      'application/json'
+      'application/xml'
+      'application/json'
+    ].forEach((mediaType, i) ->
+      context("compiles a transaction for the '#{mediaType}' media type", ->
+        it('with expected request headers', ->
+          assert.deepEqual(compilationResult.transactions[i].request.headers, {
+            'Content-Type': {value: mediaType}
+          })
+        )
+        it('with expected response headers', ->
+          assert.deepEqual(compilationResult.transactions[i].response.headers, {})
+        )
       )
     )
   )
@@ -117,17 +120,14 @@ describe('compile() · Swagger', ->
       )
     )
 
-    it('does not call detection of transaction examples', ->
+    it('does not call the detection of transaction examples', ->
       assert.isFalse(detectTransactionExampleNumbers.called)
     )
-    it('returns expected number of transactions', ->
-      assert.equal(compilationResult.transactions.length, expectedStatusCodes.length)
-    )
-    it('is compiled with no warnings', ->
-      assert.deepEqual(compilationResult.warnings, [])
-    )
-    it('is compiled with no errors', ->
-      assert.deepEqual(compilationResult.errors, [])
+    it("produces no annotations and #{expectedStatusCodes.length} transactions", ->
+      assert.jsonSchema(compilationResult, createCompilationResultSchema(
+        annotations: 0
+        transactions: expectedStatusCodes.length
+      ))
     )
 
     for statusCode, i in expectedStatusCodes
@@ -161,14 +161,11 @@ describe('compile() · Swagger', ->
       )
     )
 
-    it('is compiled with no warnings', ->
-      assert.deepEqual(compilationResult.warnings, [])
-    )
-    it('is compiled with no errors', ->
-      assert.deepEqual(compilationResult.errors, [])
-    )
-    it('returns expected number of transactions', ->
-      assert.deepEqual(compilationResult.transactions.length, 2)
+    it('produces no annotations and 2 transactions', ->
+      assert.jsonSchema(compilationResult, createCompilationResultSchema(
+        annotations: 0
+        transactions: 2
+      ))
     )
   )
 
@@ -182,14 +179,11 @@ describe('compile() · Swagger', ->
       )
     )
 
-    it('is compiled with no warnings', ->
-      assert.deepEqual(compilationResult.warnings, [])
-    )
-    it('is compiled with no errors', ->
-      assert.deepEqual(compilationResult.errors, [])
-    )
-    it('returns expected number of transactions', ->
-      assert.deepEqual(compilationResult.transactions.length, 1)
+    it('produces no annotations and 1 transaction', ->
+      assert.jsonSchema(compilationResult, createCompilationResultSchema(
+        annotations: 0
+        transactions: 1
+      ))
     )
   )
 

--- a/test/integration/compile-test.coffee
+++ b/test/integration/compile-test.coffee
@@ -45,30 +45,18 @@ describe('compile() · all API description formats', ->
         )
       )
 
-      it('is compiled into zero transactions', ->
-        assert.deepEqual(compilationResult.transactions, [])
+      it('produces one annotation and no transactions', ->
+        assert.jsonSchema(compilationResult, createCompilationResultSchema(
+          annotations: 1
+          transactions: 0
+        ))
       )
-      it('is compiled with no warnings', ->
-        assert.deepEqual(compilationResult.warnings, [])
-      )
-      it('is compiled with an error', ->
-        assert.equal(compilationResult.errors.length, 1)
-      )
-      context('the error', ->
-        it('comes from parser', ->
-          assert.equal(compilationResult.errors[0].component, 'apiDescriptionParser')
+      context('the annotation', ->
+        it('is error', ->
+          assert.equal(compilationResult.annotations[0].type, 'error')
         )
-        it('has code', ->
-          assert.isNumber(compilationResult.errors[0].code)
-        )
-        it('has message', ->
-          assert.isString(compilationResult.errors[0].message)
-        )
-        it('has location', ->
-          assert.jsonSchema(compilationResult.errors[0].location, locationSchema)
-        )
-        it('has no origin', ->
-          assert.isUndefined(compilationResult.errors[0].origin)
+        it('comes from the parser', ->
+          assert.equal(compilationResult.annotations[0].component, 'apiDescriptionParser')
         )
       )
     )
@@ -91,33 +79,22 @@ describe('compile() · all API description formats', ->
         )
       )
 
-      it('is compiled into zero transactions', ->
-        assert.deepEqual(compilationResult.transactions, [])
+      it('produces some annotations and no transactions', ->
+        assert.jsonSchema(compilationResult, createCompilationResultSchema(
+          annotations: true
+          transactions: 0
+        ))
       )
       it('is compiled with maximum one warning from parser', ->
-        assert.isAtMost(compilationResult.warnings.length, 1)
-        if compilationResult.warnings.length
-          assert.equal(compilationResult.warnings[0].component, 'apiDescriptionParser')
+        warnings = compilationResult.annotations.filter((ann) -> ann.type is 'warning')
+        assert.isAtMost(warnings.length, 1)
+        assert.equal(warnings[0].component, 'apiDescriptionParser') if warnings.length
       )
-      it('is compiled with one error', ->
-        assert.equal(compilationResult.errors.length, 1)
-      )
-      context('the error', ->
-        it('comes from URI expansion', ->
-          assert.equal(compilationResult.errors[0].component, 'uriTemplateExpansion')
-        )
-        it('has no code', ->
-          assert.isUndefined(compilationResult.errors[0].code)
-        )
-        it('has message', ->
-          assert.include(compilationResult.errors[0].message.toLowerCase(), 'failed to parse uri template')
-        )
-        it('has location', ->
-          assert.jsonSchema(compilationResult.errors[0].location, locationSchema)
-        )
-        it('has origin', ->
-          assert.jsonSchema(compilationResult.errors[0].origin, originSchema)
-        )
+      it('is compiled with one error from URI expansion', ->
+        errors = compilationResult.annotations.filter((ann) -> ann.type is 'error')
+        assert.equal(errors.length, 1)
+        assert.equal(errors[0].component, 'uriTemplateExpansion') if errors.length
+        assert.include(errors[0].message.toLowerCase(), 'failed to parse uri template')
       )
     )
   )
@@ -140,43 +117,33 @@ describe('compile() · all API description formats', ->
         )
       )
 
-      it('is compiled into zero transactions', ->
-        assert.deepEqual(compilationResult.transactions, [])
+      it('produces some annotations and no transactions', ->
+        assert.jsonSchema(compilationResult, createCompilationResultSchema(
+          annotations: true
+          transactions: 0
+        ))
       )
       it('is compiled with maximum two warnings', ->
-        assert.isAtMost(compilationResult.warnings.length, 2)
+        warnings = compilationResult.annotations.filter((ann) -> ann.type is 'warning')
+        assert.isAtMost(warnings.length, 2)
       )
-      it('there is maximum one warning from parser', ->
-        warnings = compilationResult.warnings.filter((warning) ->
-          warning.component is 'apiDescriptionParser'
+      it('is compiled with maximum one warning from parser', ->
+        warnings = compilationResult.annotations.filter((ann) ->
+          ann.type is 'warning' and ann.component is 'apiDescriptionParser'
         )
         assert.isAtMost(warnings.length, 1)
       )
-      it('there is one warning from URI expansion', ->
-        warnings = compilationResult.warnings.filter((warning) ->
-          warning.component is 'uriTemplateExpansion'
+      it('is compiled with one warning from URI expansion', ->
+        warnings = compilationResult.annotations.filter((ann) ->
+          ann.type is 'warning' and ann.component is 'uriTemplateExpansion'
         )
         assert.equal(warnings.length, 1)
       )
-      it('is compiled with one error', ->
-        assert.equal(compilationResult.errors.length, 1)
-      )
-      context('the error', ->
-        it('comes from URI parameters validation', ->
-          assert.equal(compilationResult.errors[0].component, 'parametersValidation')
-        )
-        it('has no code', ->
-          assert.isUndefined(compilationResult.errors[0].code)
-        )
-        it('has message', ->
-          assert.include(compilationResult.errors[0].message.toLowerCase(), 'no example')
-        )
-        it('has location', ->
-          assert.jsonSchema(compilationResult.errors[0].location, locationSchema)
-        )
-        it('has origin', ->
-          assert.jsonSchema(compilationResult.errors[0].origin, originSchema)
-        )
+      it('is compiled with one error from URI parameters validation', ->
+        errors = compilationResult.annotations.filter((ann) -> ann.type is 'error')
+        assert.equal(errors.length, 1)
+        assert.equal(errors[0].component, 'parametersValidation')
+        assert.include(errors[0].message.toLowerCase(), 'no example')
       )
     )
   )
@@ -192,36 +159,21 @@ describe('compile() · all API description formats', ->
         )
       )
 
-      it('is compiled into expected number of transactions', ->
-        assert.equal(compilationResult.transactions.length, 1)
+      it('produces some annotations and one transaction', ->
+        assert.jsonSchema(compilationResult, createCompilationResultSchema(
+          annotations: true
+          transactions: 1
+        ))
       )
-      it('is compiled with some warnings', ->
-        assert.ok(compilationResult.warnings.length)
-      )
-      context('the warnings', ->
-        it('comes from parser', ->
-          for warning in compilationResult.warnings
-            assert.equal(warning.component, 'apiDescriptionParser')
+      context('the annotations', ->
+        it('are warnings', ->
+          for ann in compilationResult.annotations
+            assert.equal(ann.type, 'warning')
         )
-        it('have code', ->
-          for warning in compilationResult.warnings
-            assert.isNumber(warning.code)
+        it('come from parser', ->
+          for ann in compilationResult.annotations
+            assert.equal(ann.component, 'apiDescriptionParser')
         )
-        it('have message', ->
-          for warning in compilationResult.warnings
-            assert.isString(warning.message)
-        )
-        it('have location', ->
-          for warning in compilationResult.warnings
-            assert.jsonSchema(warning.location, locationSchema)
-        )
-        it('have no origin', ->
-          for warning in compilationResult.warnings
-            assert.isUndefined(warning.origin)
-        )
-      )
-      it('is compiled with no errors', ->
-        assert.deepEqual(compilationResult.errors, [])
       )
     )
   )
@@ -252,36 +204,25 @@ describe('compile() · all API description formats', ->
         )
       )
 
-      it('is compiled into some transactions', ->
-        assert.ok(compilationResult.transactions.length)
+      it('produces some annotations and some transactions', ->
+        assert.jsonSchema(compilationResult, createCompilationResultSchema(
+          annotations: true
+          transactions: true
+        ))
       )
-      it('is compiled with some warnings', ->
-        assert.ok(compilationResult.warnings.length)
-      )
-      context('the warnings', ->
+      context('the annotations', ->
+        it('are warnings', ->
+          for ann in compilationResult.annotations
+            assert.equal(ann.type, 'warning')
+        )
         it('come from URI expansion', ->
-          for warning in compilationResult.warnings
-            assert.equal(warning.component, 'uriTemplateExpansion')
+          for ann in compilationResult.annotations
+            assert.equal(ann.component, 'uriTemplateExpansion')
         )
-        it('have no code', ->
-          for warning in compilationResult.warnings
-            assert.isUndefined(warning.code)
+        it('have the expected message', ->
+          for ann in compilationResult.annotations
+            assert.include(ann.message, message)
         )
-        it('have message', ->
-          for warning in compilationResult.warnings
-            assert.include(warning.message, message)
-        )
-        it('have location', ->
-          for warning in compilationResult.warnings
-            assert.jsonSchema(warning.location, locationSchema)
-        )
-        it('have origin', ->
-          for warning in compilationResult.warnings
-            assert.jsonSchema(warning.origin, originSchema)
-        )
-      )
-      it('is compiled with no errors', ->
-        assert.deepEqual(compilationResult.errors, [])
       )
     )
   )
@@ -306,32 +247,21 @@ describe('compile() · all API description formats', ->
         )
       )
 
-      it('is compiled into zero transactions', ->
-        assert.deepEqual(compilationResult.transactions, [])
+      it('produces one annotation and no transactions', ->
+        assert.jsonSchema(compilationResult, createCompilationResultSchema(
+          annotations: 2
+          transactions: 0
+        ))
       )
-      it('is compiled with one warning', ->
-        assert.equal(compilationResult.warnings.length, 1)
-      )
-      context('the warning', ->
-        it('comes from URI expansion', ->
-          assert.equal(compilationResult.warnings[0].component, 'uriTemplateExpansion')
-        )
-        it('has no code', ->
-          assert.isUndefined(compilationResult.warnings[0].code)
-        )
-        it('has message', ->
-          assert.include(compilationResult.warnings[0].message.toLowerCase(), 'ambiguous')
-        )
-        it('has location', ->
-          assert.jsonSchema(compilationResult.warnings[0].location, locationSchema)
-        )
-        it('has origin', ->
-          assert.jsonSchema(compilationResult.warnings[0].origin, originSchema)
-        )
+      it('is compiled with one warning from URI expansion', ->
+        warnings = compilationResult.annotations.filter((ann) -> ann.type is 'warning')
+        assert.equal(warnings.length, 1)
+        assert.equal(warnings[0].component, 'uriTemplateExpansion')
       )
       it('is compiled with one error from URI parameters validation', ->
-        assert.equal(compilationResult.errors.length, 1)
-        assert.equal(compilationResult.errors[0].component, 'parametersValidation')
+        errors = compilationResult.annotations.filter((ann) -> ann.type is 'error')
+        assert.equal(errors.length, 1)
+        assert.equal(errors[0].component, 'parametersValidation')
       )
     )
   )
@@ -358,36 +288,25 @@ describe('compile() · all API description formats', ->
         )
       )
 
-      it('is compiled into some transactions', ->
-        assert.ok(compilationResult.transactions.length)
+      it('produces some annotations and some transactions', ->
+        assert.jsonSchema(compilationResult, createCompilationResultSchema(
+          annotations: true
+          transactions: true
+        ))
       )
-      it('is compiled with some warnings', ->
-        assert.ok(compilationResult.warnings.length)
-      )
-      context('the warnings', ->
+      context('the annotations', ->
+        it('are warnings', ->
+          for ann in compilationResult.annotations
+            assert.equal(ann.type, 'warning')
+        )
         it('come from URI parameters validation', ->
-          for warning in compilationResult.warnings
-            assert.equal(warning.component, 'parametersValidation')
+          for ann in compilationResult.annotations
+            assert.equal(ann.component, 'parametersValidation')
         )
-        it('have no code', ->
-          for warning in compilationResult.warnings
-            assert.isUndefined(warning.code)
+        it('have the expected message', ->
+          for ann in compilationResult.annotations
+            assert.include(ann.message, message)
         )
-        it('have message', ->
-          for warning in compilationResult.warnings
-            assert.include(warning.message, message)
-        )
-        it('have location', ->
-          for warning in compilationResult.warnings
-            assert.jsonSchema(warning.location, locationSchema)
-        )
-        it('have origin', ->
-          for warning in compilationResult.warnings
-            assert.jsonSchema(warning.origin, originSchema)
-        )
-      )
-      it('is compiled with no errors', ->
-        assert.deepEqual(compilationResult.errors, [])
       )
     )
   )
@@ -403,11 +322,11 @@ describe('compile() · all API description formats', ->
         )
       )
 
-      it('is compiled with no warnings', ->
-        assert.deepEqual(compilationResult.warnings, [])
-      )
-      it('is compiled with no errors', ->
-        assert.deepEqual(compilationResult.errors, [])
+      it('produces no annotations and one transaction', ->
+        assert.jsonSchema(compilationResult, createCompilationResultSchema(
+          annotations: 0
+          transactions: 1
+        ))
       )
       it('expands the request URI with the first enum value', ->
         assert.equal(compilationResult.transactions[0].request.uri, '/honey?beekeeper=Adam')
@@ -426,11 +345,11 @@ describe('compile() · all API description formats', ->
         )
       )
 
-      it('is compiled with no warnings', ->
-        assert.deepEqual(compilationResult.warnings, [])
-      )
-      it('is compiled with no errors', ->
-        assert.deepEqual(compilationResult.errors, [])
+      it('produces no annotations and one transaction', ->
+        assert.jsonSchema(compilationResult, createCompilationResultSchema(
+          annotations: 0
+          transactions: 1
+        ))
       )
       it('expands the request URI with the example value', ->
         assert.equal(compilationResult.transactions[0].request.uri, '/honey?beekeeper=Honza')
@@ -455,32 +374,23 @@ describe('compile() · all API description formats', ->
         )
       )
 
-      it('is compiled into one transaction', ->
-        assert.equal(compilationResult.transactions.length, 1)
+      it('produces some annotations and one transaction', ->
+        assert.jsonSchema(compilationResult, createCompilationResultSchema(
+          annotations: true
+          transactions: 1
+        ))
       )
       it('is compiled with maximum one warning from parser', ->
-        if compilationResult.warnings.length
-          assert.equal(compilationResult.warnings[0].component, 'apiDescriptionParser')
+        warnings = compilationResult.annotations.filter((ann) ->
+          ann.type is 'warning' and ann.component is 'apiDescriptionParser'
+        )
+        assert.isAtMost(warnings.length, 1)
       )
-      it('is compiled with one error', ->
-        assert.equal(compilationResult.errors.length, 1)
-      )
-      context('the error', ->
-        it('comes from URI parameters validation', ->
-          assert.equal(compilationResult.errors[0].component, 'parametersValidation')
-        )
-        it('has no code', ->
-          assert.isUndefined(compilationResult.errors[0].code)
-        )
-        it('has message', ->
-          assert.include(compilationResult.errors[0].message.toLowerCase(), 'example value is not one of enum values')
-        )
-        it('has location', ->
-          assert.jsonSchema(compilationResult.errors[0].location, locationSchema)
-        )
-        it('has origin', ->
-          assert.jsonSchema(compilationResult.errors[0].origin, originSchema)
-        )
+      it('is compiled with one error from URI parameters validation', ->
+        errors = compilationResult.annotations.filter((ann) -> ann.type is 'error')
+        assert.equal(errors.length, 1)
+        assert.equal(errors[0].component, 'parametersValidation')
+        assert.include(errors[0].message.toLowerCase(), 'example value is not one of enum values')
       )
       it('expands the request URI with the example value', ->
         assert.equal(compilationResult.transactions[0].request.uri, '/honey?beekeeper=Pavan')
@@ -499,11 +409,11 @@ describe('compile() · all API description formats', ->
         )
       )
 
-      it('is compiled with no warnings', ->
-        assert.deepEqual(compilationResult.warnings, [])
-      )
-      it('is compiled with no errors', ->
-        assert.deepEqual(compilationResult.errors, [])
+      it('produces no annotations and one transaction', ->
+        assert.jsonSchema(compilationResult, createCompilationResultSchema(
+          annotations: 0
+          transactions: 1
+        ))
       )
       it('expands the request URI with the example value', ->
         assert.equal(compilationResult.transactions[0].request.uri, '/honey?beekeeper=Honza&flavour=spicy')
@@ -522,19 +432,30 @@ describe('compile() · all API description formats', ->
         )
       )
 
-      it('is compiled with no warnings', ->
-        assert.deepEqual(compilationResult.warnings, [])
+      it('produces no annotations and one transaction', ->
+        assert.jsonSchema(compilationResult, createCompilationResultSchema(
+          annotations: 0
+          transactions: 2
+        ))
       )
-      it('is compiled with no errors', ->
-        assert.deepEqual(compilationResult.errors, [])
+      context('the first transaction', ->
+        it('has the body in response data', ->
+          assert.ok(compilationResult.transactions[0].response.body)
+          assert.doesNotThrow( -> JSON.parse(compilationResult.transactions[0].response.body))
+        )
+        it('has the schema in response data', ->
+          assert.ok(compilationResult.transactions[0].response.schema)
+          assert.doesNotThrow( -> JSON.parse(compilationResult.transactions[0].response.schema))
+        )
       )
-      it('provides the body in response data', ->
-        assert.ok(compilationResult.transactions[0].response.body)
-        assert.doesNotThrow( -> JSON.parse(compilationResult.transactions[0].response.body))
-      )
-      it('provides the schema in response data', ->
-        assert.ok(compilationResult.transactions[0].response.schema)
-        assert.doesNotThrow( -> JSON.parse(compilationResult.transactions[0].response.schema))
+      context('the second transaction', ->
+        it('has no body in response data', ->
+          assert.notOk(compilationResult.transactions[1].response.body)
+        )
+        it('has the schema in response data', ->
+          assert.ok(compilationResult.transactions[1].response.schema)
+          assert.doesNotThrow( -> JSON.parse(compilationResult.transactions[1].response.schema))
+        )
       )
     )
   )
@@ -550,11 +471,11 @@ describe('compile() · all API description formats', ->
         )
       )
 
-      it('is compiled with no warnings', ->
-        assert.deepEqual(compilationResult.warnings, [])
-      )
-      it('is compiled with no errors', ->
-        assert.deepEqual(compilationResult.errors, [])
+      it('produces no annotations and one transaction', ->
+        assert.jsonSchema(compilationResult, createCompilationResultSchema(
+          annotations: 0
+          transactions: 1
+        ))
       )
       it('expands the request URI using correct inheritance cascade', ->
         assert.equal(compilationResult.transactions[0].request.uri, '/honey?beekeeper=Honza&amount=42')
@@ -573,11 +494,11 @@ describe('compile() · all API description formats', ->
         )
       )
 
-      it('is compiled with no warnings', ->
-        assert.deepEqual(compilationResult.warnings, [])
-      )
-      it('is compiled with no errors', ->
-        assert.deepEqual(compilationResult.errors, [])
+      it('produces no annotations and one transaction', ->
+        assert.jsonSchema(compilationResult, createCompilationResultSchema(
+          annotations: 0
+          transactions: 1
+        ))
       )
       it('expands the request URI using the default value', ->
         assert.equal(compilationResult.transactions[0].request.uri, '/honey?beekeeper=Adam')
@@ -596,48 +517,30 @@ describe('compile() · all API description formats', ->
         )
       )
 
-      it('expands the request URI using the default value', ->
-        assert.equal(compilationResult.transactions[0].request.uri, '/honey?beekeeper=Honza')
+      it('produces some annotations and one transaction', ->
+        assert.jsonSchema(compilationResult, createCompilationResultSchema(
+          annotations: true
+          transactions: 1
+        ))
       )
-      it('is compiled with no errors', ->
-        assert.deepEqual(compilationResult.errors, [])
+      it('is compiled with maximum three annotations', ->
+        assert.isAtMost(compilationResult.annotations.length, 3)
       )
-      it('is compiled with maximum two warnings', ->
-        assert.isAtMost(compilationResult.warnings.length, 2)
-      )
-      it('there is maximum one warning from parser', ->
-        warnings = compilationResult.warnings.filter((warning) ->
-          warning.component is 'apiDescriptionParser'
+      it('is compiled with maximum one warning from parser', ->
+        warnings = compilationResult.annotations.filter((ann) ->
+          ann.type is 'warning' and ann.component is 'apiDescriptionParser'
         )
         assert.isAtMost(warnings.length, 1)
       )
-      it('there is one warning from URI expansion', ->
-        warnings = compilationResult.warnings.filter((warning) ->
-          warning.component is 'uriTemplateExpansion'
+      it('is compiled with one warning from URI expansion', ->
+        warnings = compilationResult.annotations.filter((ann) ->
+          ann.type is 'warning' and ann.component is 'uriTemplateExpansion'
         )
         assert.equal(warnings.length, 1)
+        assert.include(warnings[0].message.toLowerCase(), 'default value for a required parameter')
       )
-      context('the last warning', ->
-        it('comes from URI expansion', ->
-          lastWarning = compilationResult.warnings[compilationResult.warnings.length - 1]
-          assert.equal(lastWarning.component, 'uriTemplateExpansion')
-        )
-        it('has no code', ->
-          lastWarning = compilationResult.warnings[compilationResult.warnings.length - 1]
-          assert.isUndefined(lastWarning.code)
-        )
-        it('has message', ->
-          lastWarning = compilationResult.warnings[compilationResult.warnings.length - 1]
-          assert.include(lastWarning.message.toLowerCase(), 'default value for a required parameter')
-        )
-        it('has location', ->
-          lastWarning = compilationResult.warnings[compilationResult.warnings.length - 1]
-          assert.jsonSchema(lastWarning.location, locationSchema)
-        )
-        it('has origin', ->
-          lastWarning = compilationResult.warnings[compilationResult.warnings.length - 1]
-          assert.jsonSchema(lastWarning.origin, originSchema)
-        )
+      it('expands the request URI using the default value', ->
+        assert.equal(compilationResult.transactions[0].request.uri, '/honey?beekeeper=Honza')
       )
     )
   )
@@ -653,25 +556,23 @@ describe('compile() · all API description formats', ->
         )
       )
 
-      it('is compiled with no warnings', ->
-        assert.deepEqual(compilationResult.warnings, [])
+      it('produces no annotations and one transaction', ->
+        assert.jsonSchema(compilationResult, createCompilationResultSchema(
+          annotations: 0
+          transactions: 1
+        ))
       )
-      it('is compiled with no errors', ->
-        assert.deepEqual(compilationResult.errors, [])
+      it('produces expected request headers', ->
+        assert.deepEqual(compilationResult.transactions[0].request.headers, {
+          'Content-Type': {value: 'application/json'}
+          'Accept': {value: 'application/json'}
+        })
       )
-      context('compiles a transaction', ->
-        it('with expected request headers', ->
-          assert.deepEqual(compilationResult.transactions[0].request.headers, {
-            'Content-Type': {value: 'application/json'}
-            'Accept': {value: 'application/json'}
-          })
-        )
-        it('with expected response headers', ->
-          assert.deepEqual(compilationResult.transactions[0].response.headers, {
-            'Content-Type': {value: 'application/json'}
-            'X-Test': {value: 'Adam'}
-          })
-        )
+      it('produces expected response headers', ->
+        assert.deepEqual(compilationResult.transactions[0].response.headers, {
+          'Content-Type': {value: 'application/json'}
+          'X-Test': {value: 'Adam'}
+        })
       )
     )
   )

--- a/test/integration/dredd-transactions-test.coffee
+++ b/test/integration/dredd-transactions-test.coffee
@@ -72,9 +72,9 @@ describe('Dredd Transactions', ->
       )
     )
 
-    it('produces one annotation, no transactions', ->
+    it('produces two annotations, no transactions', ->
       assert.jsonSchema(compilationResult, createCompilationResultSchema(
-        annotations: 1
+        annotations: 2
         transactions: 0
       ))
     )
@@ -83,6 +83,13 @@ describe('Dredd Transactions', ->
       assert.include(
         compilationResult.annotations[0].message,
         'to API Blueprint'
+      )
+    )
+    it('produces a warning about the API Blueprint not being valid', ->
+      assert.equal(compilationResult.annotations[1].type, 'warning')
+      assert.include(
+        compilationResult.annotations[1].message,
+        'expected'
       )
     )
   )
@@ -162,10 +169,10 @@ describe('Dredd Transactions', ->
         )
       )
 
-      it('produces some annotations, no transactions', ->
+      it('produces some annotations, some transactions', ->
         assert.jsonSchema(compilationResult, createCompilationResultSchema(
           annotations: true
-          transactions: 0
+          transactions: true
         ))
       )
       it('produces no errors', ->

--- a/test/schemas/compilation-result.coffee
+++ b/test/schemas/compilation-result.coffee
@@ -36,7 +36,13 @@ module.exports = (options = {}) ->
         ]
       message: {type: 'string'}
       location: createLocationSchema()
+      origin: createOriginSchema({filename})
     required: ['type', 'component', 'message', 'location']
+    dependencies:
+      origin:
+        properties:
+          component:
+            enum: ['parametersValidation', 'uriTemplateExpansion']
     additionalProperties: false
 
   requestSchema =
@@ -83,12 +89,22 @@ module.exports = (options = {}) ->
     required: ['request', 'response', 'origin', 'name', 'pathOrigin', 'path']
     additionalProperties: false
 
+  transactionsSchema = addMinMax(
+    type: 'array'
+    items: transactionSchema
+  , transactions)
+
+  annotationsSchema = addMinMax(
+    type: 'array'
+    items: annotationSchema
+  , annotations)
+
   {
     type: 'object'
     properties:
       mediaType: {anyOf: [{type: 'string'}, {type: 'null'}]}
-      transactions: addMinMax({type: 'array', items: transactionSchema}, transactions)
-      annotations: addMinMax({type: 'array', items: annotationSchema}, annotations)
+      transactions: transactionsSchema
+      annotations: annotationsSchema
     required: ['mediaType', 'transactions', 'annotations']
     additionalProperties: false
   }

--- a/test/schemas/compilation-result.coffee
+++ b/test/schemas/compilation-result.coffee
@@ -1,4 +1,5 @@
 
+createLocationSchema = require('./location')
 createOriginSchema = require('./origin')
 createPathOriginSchema = require('./path-origin')
 
@@ -17,17 +18,26 @@ module.exports = (options = {}) ->
   filename = options.filename
 
   # Either exact number or true (= more than one)
-  errors = options.errors or 0
-  warnings = options.warnings or 0
+  annotations = options.annotations or 0
   transactions = options.transactions or 0
 
-  # Either false (= no media type property should be present) or it
-  # will default to true (= structure must contain media type property)
-  mediaType = if options.mediaType is false then false else true
-
-  # Either false (= no transaction names and paths should be present) or it
-  # will default to true (= structure must contain transaction names and paths)
-  paths = if options.paths is false then false else true
+  annotationSchema =
+    type: 'object'
+    properties:
+      type:
+        type: 'string'
+        enum: ['error', 'warning']
+      component:
+        type: 'string'
+        enum: [
+          'apiDescriptionParser'
+          'parametersValidation'
+          'uriTemplateExpansion'
+        ]
+      message: {type: 'string'}
+      location: createLocationSchema()
+    required: ['type', 'component', 'message', 'location']
+    additionalProperties: false
 
   requestSchema =
     type: 'object'
@@ -61,38 +71,24 @@ module.exports = (options = {}) ->
     required: ['status', 'headers', 'body', 'schema']
     additionalProperties: false
 
-  originSchema = createOriginSchema({filename})
-  pathOriginSchema = createPathOriginSchema()
-
   transactionSchema =
     type: 'object'
     properties:
       request: requestSchema
       response: responseSchema
-      origin: originSchema
-      pathOrigin: pathOriginSchema
-    required: ['request', 'response', 'origin', 'pathOrigin']
+      origin: createOriginSchema({filename})
+      name: {type: 'string'}
+      pathOrigin: createPathOriginSchema()
+      path: {type: 'string'}
+    required: ['request', 'response', 'origin', 'name', 'pathOrigin', 'path']
     additionalProperties: false
-
-  if paths
-    transactionSchema.properties.name = {type: 'string'}
-    transactionSchema.required.push('name')
-    transactionSchema.properties.path = {type: 'string'}
-    transactionSchema.required.push('path')
-
-  properties =
-    transactions: addMinMax({type: 'array', items: transactionSchema}, transactions)
-    errors: addMinMax({type: 'array'}, errors)
-    warnings: addMinMax({type: 'array'}, warnings)
-  required = ['transactions', 'errors', 'warnings']
-
-  if mediaType
-    properties.mediaType = {anyOf: [{type: 'string'}, {type: 'null'}]}
-    required.push('mediaType')
 
   {
     type: 'object'
-    properties
-    required
+    properties:
+      mediaType: {anyOf: [{type: 'string'}, {type: 'null'}]}
+      transactions: addMinMax({type: 'array', items: transactionSchema}, transactions)
+      annotations: addMinMax({type: 'array', items: annotationSchema}, annotations)
+    required: ['mediaType', 'transactions', 'annotations']
     additionalProperties: false
   }


### PR DESCRIPTION
Third attempt to close #19, Travis CI to blame this time - see https://github.com/apiaryio/dredd-transactions/pull/113#issuecomment-339314381.

### BREAKING CHANGE

This changes the structure of Dredd Transactions' output. Instead of `errors` and `warnings` arrays, there is now just one array called `annotations`. Individual annotations have `type` property, which can be either `error` or `warning`.

-----

There will be multiple breaking changes. I created `honzajavorek/breaking-changes` branch, which will contain them and once they're all there and reviewed, the branch can be merged into `master`. Thanks to this we should get just one major version bump using the Semantic Release.

This PR is to the `honzajavorek/breaking-changes` branch.