### PR TITLE
Fix commitlint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ cache:
   directories:
     - "node_modules"
 before_install:
-  - "git fetch --unshallow"  # for commitlint to work
   - "npm -g install npm@latest"
 install: "if [[ $DRAFTER = JS ]]; then npm install --no-optional; else npm install; fi"
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,7 @@ before_install:
   - "npm -g install npm@latest"
 install: "if [[ $DRAFTER = JS ]]; then npm install --no-optional; else npm install; fi"
 script:
-  - "npm run lint"
-  - "npm run test:coverage"
+  - "npm run lint && npm run test:coverage"
 after_success:
   - "npm run coveralls || true"
   - "npm run semantic-release || true"

--- a/scripts/commitlint.sh
+++ b/scripts/commitlint.sh
@@ -5,9 +5,12 @@
 set -e # aborts as soon as anything returns non-zero exit status
 
 
-git remote set-branches origin master
-git fetch --unshallow --quiet
-git checkout master --quiet
-git checkout - --quiet
-
-./node_modules/.bin/commitlint --from=master --to="$TRAVIS_COMMIT"
+if [ ! -z "$TRAVIS_COMMIT" ]; then
+    git remote set-branches origin master
+    git fetch --unshallow --quiet
+    git checkout master --quiet
+    git checkout - --quiet
+    ./node_modules/.bin/commitlint --from=master --to="$TRAVIS_COMMIT"
+else
+    ./node_modules/.bin/commitlint --from=master
+fi

--- a/scripts/commitlint.sh
+++ b/scripts/commitlint.sh
@@ -1,31 +1,13 @@
 #!/bin/bash
 # Validates format of the commit messages on Travis CI
 
-# Copyright (c) 2016 Mario Nebl
-# License: MIT (https://github.com/marionebl/commitlint/blob/master/license.md)
-# Source: https://marionebl.github.io/commitlint/#/guides-ci-setup
 
-set -e
-set -u
+set -e # aborts as soon as anything returns non-zero exit status
 
 
-if [[ $TRAVIS_PULL_REQUEST_SLUG != "" && $TRAVIS_PULL_REQUEST_SLUG != $TRAVIS_REPO_SLUG ]]; then
-    # This is a Pull Request from a different slug, hence a forked repository
-    git remote add "$TRAVIS_PULL_REQUEST_SLUG" "https://github.com/$TRAVIS_PULL_REQUEST_SLUG.git"
-    git fetch "$TRAVIS_PULL_REQUEST_SLUG"
+git remote set-branches origin master
+git fetch --unshallow --quiet
+git checkout master --quiet
+git checkout - --quiet
 
-    # Use the fetched remote pointing to the source clone for comparison
-    TO="$TRAVIS_PULL_REQUEST_SLUG/$TRAVIS_PULL_REQUEST_BRANCH"
-else
-    # This is a Pull Request from the same remote, no clone repository
-    TO=$TRAVIS_COMMIT
-fi
-
-# Lint all commits in the PR
-# - Covers fork pull requests (when TO=slug/branch)
-# - Covers branch pull requests (when TO=branch)
-./node_modules/.bin/commitlint --from="$TRAVIS_BRANCH" --to="$TO"
-
-# Always lint the triggerig commit
-# - Covers direct commits
-./node_modules/.bin/commitlint --from="$TRAVIS_COMMIT"
+./node_modules/.bin/commitlint --from=master --to="$TRAVIS_COMMIT"

--- a/scripts/commitlint.sh
+++ b/scripts/commitlint.sh
@@ -5,12 +5,10 @@
 set -e # aborts as soon as anything returns non-zero exit status
 
 
-if [ ! -z "$TRAVIS_COMMIT" ]; then
+if [ ! -z "$TRAVIS" ]; then
     git remote set-branches origin master
     git fetch --unshallow --quiet
     git checkout master --quiet
     git checkout - --quiet
-    ./node_modules/.bin/commitlint --from=master --to="$TRAVIS_COMMIT"
-else
-    ./node_modules/.bin/commitlint --from=master
 fi
+./node_modules/.bin/commitlint --from=master


### PR DESCRIPTION
Current `commitlint` setup has some issues with identifying the right commits ([see failed build here](https://travis-ci.org/apiaryio/dredd-transactions/builds/292593883)). This solution is a mix of [the original magic](https://github.com/apiaryio/dredd-transactions/commit/9d6bdb04a3591429fc1e22f8cf9db215f996f0a9#diff-354f30a63fb0907d4ad57269548329e3R18) from https://github.com/marionebl/commitlint/issues/7#issuecomment-231217850 and the `git fetch --unshallow` from the [current `commitlint` Travis CI tutorial](https://marionebl.github.io/commitlint/#/guides-ci-setup).

I tested following scenarios:

- Push
- PR
- Push in a forked repository
- PR from a forked repository

All seem to work.