### PR TITLE
Update Swagger adapter, pin Fury deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
   "dependencies": {
     "caseless": "^0.12.0",
     "clone": "^2.1.1",
-    "fury": "^3.0.0-beta.4",
-    "fury-adapter-apib-parser": "^0.9.0",
-    "fury-adapter-swagger": "^0.14.2",
+    "fury": "3.0.0-beta.4",
+    "fury-adapter-apib-parser": "0.9.0",
+    "fury-adapter-swagger": "0.15.0",
     "uri-template": "^1.0.0"
   },
   "devDependencies": {

--- a/test/integration/compile-swagger-test.coffee
+++ b/test/integration/compile-swagger-test.coffee
@@ -107,7 +107,7 @@ describe('compile() · Swagger', ->
     compilationResult = undefined
     filename = 'apiDescription.json'
     detectTransactionExampleNumbers = sinon.spy(require('../../src/detect-transaction-example-numbers'))
-    expectedStatusCodes = [200, 200, 400, 400, 500, 500]
+    expectedStatusCodes = [200, 400, 500]
 
     beforeEach((done) ->
       stubs = {'./detect-transaction-example-numbers': detectTransactionExampleNumbers}
@@ -122,6 +122,11 @@ describe('compile() · Swagger', ->
     )
     it('returns expected number of transactions', ->
       assert.equal(compilationResult.transactions.length, expectedStatusCodes.length)
+    )
+    it('skips non-JSON media types in \'produces\'', ->
+      compilationResult.transactions.forEach((transaction) ->
+        assert.equal(transaction.response.headers['Content-Type'].value, 'application/json')
+      )
     )
     it('is compiled with no warnings', ->
       assert.deepEqual(compilationResult.warnings, [])
@@ -142,10 +147,9 @@ describe('compile() · Swagger', ->
           )
 
           it('uses status code and response\'s Content-Type as example name', ->
-            contentType = if i % 2 then 'application/json' else 'application/xml'
             assert.equal(
               compilationResult.transactions[i].origin.exampleName,
-              "#{statusCode} > #{contentType}"
+              "#{statusCode} > application/json"
             )
           )
         )


### PR DESCRIPTION
Changes in the Swagger adapter:

- Sample values are now generated for data structures of object and array types.
- Request/Response pairs are now generated from explicit examples, or the first JSON produces content-type.
- Generated multipart form-data example requests were missing the end of the multi-part.
- example properties in Schema Object are not respected in data structure generation.

Related to https://github.com/apiaryio/dredd/issues/905, https://github.com/apiaryio/dredd/issues/553, https://github.com/apiaryio/dredd/issues/897, https://github.com/apiaryio/dredd/issues/883