### PR TITLE
Interface clean up (breaking changes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,7 @@ Result of compilation. Alongside compiled [Transaction][transaction-object-spec]
 
 - `mediaType`: `text/vnd.apiblueprint` (string, default, nullable) - Media type of the input format, defaults to API Blueprint format. Can be empty in case of some fatal errors.
 - `transactions` (array[[Transaction][transaction-object-spec]]) - Compiled _HTTP Transactions_.
-- `errors` (array[[Annotation][annotation-object-spec]]) - Errors which occurred during parsing of the API description or during compilation of transactions.
-- `warnings` (array[[Annotation][annotation-object-spec]]) - Warnings which occurred during parsing of the API description or during compilation of transactions.
+- `annotations` (array[[Annotation][annotation-object-spec]]) - Errors and warnings which occurred during parsing of the API description or during compilation of transactions.
 
 <a name="transaction-object"></a>
 ### Transaction (object)
@@ -136,11 +135,13 @@ Description of an error or warning which occurred during parsing of the API desc
 
 #### Properties
 
+- type (enum[string])
+    - `error`
+    - `warning`
 - component (enum[string]) - In which component of the compilation process the annotation occurred.
     - `apiDescriptionParser`
     - `parametersValidation`
     - `uriTemplateExpansion`
-- code (number) - Parser-specific code of the annotation.
 - message (string) - Textual annotation. This is – in most cases – a human-readable message to be displayed to user.
 - location (array) - Locations of the annotation in the source file. A series of character-blocks, which may be non-continuous. For further details refer to API Elements' [Source Map](source-map) element.
     - (array, fixed) - Continuous characters block. A pair of character index and character count.

--- a/README.md
+++ b/README.md
@@ -100,11 +100,17 @@ Represents a single *HTTP Transaction* (Request-Response pair) and its location 
 - request (object) - HTTP Request as described in API description document.
     - method
     - uri: `/message` (string) - Informative URI of the Request.
-    - headers (object)
+    - headers (array) - List of HTTP headers in their original order, with the original casing of the header name, including multiple headers of the same name.
+        - (object)
+            - name: `Content-Type` (string)
+            - value: `text/plain` (string)
     - body: `Hello world!\n` (string)
 - response (object) - Expected HTTP Response as described in API description document.
     - status: `200` (string)
-    - headers (object)
+    - headers (array) - List of HTTP headers in their original order, with the original casing of the header name, including multiple headers of the same name.
+        - (object)
+            - name: `Content-Type` (string)
+            - value: `text/plain` (string)
     - body (string, optional)
     - schema (string, optional)
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "url": "https://github.com/apiaryio/dredd-transactions"
   },
   "dependencies": {
-    "caseless": "^0.12.0",
     "clone": "^2.1.1",
     "fury": "3.0.0-beta.4",
     "fury-adapter-apib-parser": "0.9.0",

--- a/src/compile-uri/index.coffee
+++ b/src/compile-uri/index.coffee
@@ -4,7 +4,7 @@ expandUriTemplate = require('./expand-uri-template')
 
 
 module.exports = (httpRequestElement) ->
-  annotations = {errors: [], warnings: []}
+  annotations = []
   cascade = [
     httpRequestElement.parents.find('resource')
     httpRequestElement.parents.find('transition')
@@ -28,16 +28,16 @@ module.exports = (httpRequestElement) ->
   result = validateParams(params)
   component = 'parametersValidation'
   for error in result.errors
-    annotations.errors.push({component, message: error})
+    annotations.push({type: 'error', component, message: error})
   for warning in result.warnings
-    annotations.warnings.push({component, message: warning})
+    annotations.push({type: 'warning', component, message: warning})
 
   result = expandUriTemplate(href, params)
   component = 'uriTemplateExpansion'
   for error in result.errors
-    annotations.errors.push({component, message: error})
+    annotations.push({type: 'error', component, message: error})
   for warning in result.warnings
-    annotations.warnings.push({component, message: warning})
+    annotations.push({type: 'warning', component, message: warning})
 
   {uri: result.uri, annotations}
 

--- a/src/compile.coffee
+++ b/src/compile.coffee
@@ -10,24 +10,22 @@ compile = (mediaType, apiElements, filename) ->
   apiElements.freeze()
 
   transactions = []
-  errors = apiElements.errors.map(compileAnnotation)
-  warnings = apiElements.warnings.map(compileAnnotation)
+  annotations = apiElements.annotations.map(compileAnnotation)
 
   for {httpTransactionElement, exampleNo} in findRelevantTransactions(mediaType, apiElements)
-    {transaction, annotations} = compileTransaction(mediaType, filename, httpTransactionElement, exampleNo)
-    transactions.push(transaction) if transaction
-    errors = errors.concat(annotations.errors)
-    warnings = warnings.concat(annotations.warnings)
+    result = compileTransaction(mediaType, filename, httpTransactionElement, exampleNo)
+    transactions.push(result.transaction) if result.transaction
+    annotations = annotations.concat(result.annotations)
 
-  {mediaType, transactions, errors, warnings}
+  {mediaType, transactions, annotations}
 
 
 compileAnnotation = (annotationElement) ->
   {
+    type: annotationElement.classes.getValue(0)
     component: 'apiDescriptionParser'
-    code: annotationElement.code?.toValue()
     message: annotationElement.toValue()
-    location: annotationElement.sourceMapValue
+    location: annotationElement.sourceMapValue or [[0, 1]]
   }
 
 
@@ -72,7 +70,7 @@ compileTransaction = (mediaType, filename, httpTransactionElement, exampleNo) ->
   origin = compileOrigin(mediaType, filename, httpTransactionElement, exampleNo)
   {request, annotations} = compileRequest(httpTransactionElement.request)
 
-  [].concat(annotations.errors, annotations.warnings).forEach((annotation) ->
+  annotations.forEach((annotation) ->
     annotation.origin = clone(origin)
   )
   return {transaction: null, annotations} unless request
@@ -89,7 +87,7 @@ compileTransaction = (mediaType, filename, httpTransactionElement, exampleNo) ->
 compileRequest = (httpRequestElement) ->
   {uri, annotations} = compileUri(httpRequestElement)
 
-  [].concat(annotations.errors, annotations.warnings).forEach((annotation) ->
+  annotations.forEach((annotation) ->
     annotation.location = (
       httpRequestElement.href?.sourceMapValue or
       httpRequestElement.parents.find('transition').href?.sourceMapValue or

--- a/src/compile.coffee
+++ b/src/compile.coffee
@@ -1,5 +1,4 @@
 clone = require('clone')
-caseless = require('caseless')
 
 detectTransactionExampleNumbers = require('./detect-transaction-example-numbers')
 compileUri = require('./compile-uri')
@@ -150,7 +149,11 @@ compileOriginExampleName = (mediaType, httpResponseElement, exampleNo) ->
   else
     statusCode = httpResponseElement.statusCode?.toValue() or '200'
     headers = compileHeaders(httpResponseElement.headers)
-    contentType = caseless(headers).get('content-type')?.value
+
+    contentType = headers
+      .filter((header) -> header.name.toLowerCase() is 'content-type')
+      .map((header) -> header.value)
+      .join(', ')
 
     segments = []
     segments.push(statusCode) if statusCode
@@ -176,11 +179,10 @@ compilePathOrigin = (filename, httpTransactionElement, exampleNo) ->
 
 
 compileHeaders = (httpHeadersElement) ->
-  return {} unless httpHeadersElement
-  httpHeadersElement.toValue().reduce((headers, {key, value}) ->
-    headers[key] = {value}
-    return headers
-  , {})
+  return [] unless httpHeadersElement
+  return httpHeadersElement.toValue().map(({key, value}) ->
+    return {name: key, value}
+  )
 
 
 module.exports = compile

--- a/src/compile.coffee
+++ b/src/compile.coffee
@@ -152,8 +152,7 @@ compileOriginExampleName = (mediaType, httpResponseElement, exampleNo) ->
 
     contentType = headers
       .filter((header) -> header.name.toLowerCase() is 'content-type')
-      .map((header) -> header.value)
-      .join(', ')
+      .map((header) -> header.value)[0]
 
     segments = []
     segments.push(statusCode) if statusCode

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -3,7 +3,7 @@ compileFromApiElements = require('./compile')
 
 
 compile = (source, filename, callback) ->
-  # All regular parser-related or compilation-related errors and warnings
+  # All regular parser-related or compilation-related annotations
   # should be returned in the "compilation result". Callback should get
   # an error only in case of unexpected crash.
 
@@ -34,8 +34,7 @@ createParserErrorCompilationResult = (message) ->
   return {
     mediaType: null
     transactions: []
-    warnings: []
-    errors: [{component: 'apiDescriptionParser', message}]
+    annotations: [{type: 'error', component: 'apiDescriptionParser', message, location: [[0, 1]]}]
   }
 
 

--- a/src/parse.coffee
+++ b/src/parse.coffee
@@ -36,6 +36,9 @@ parse = (source, callback) ->
 createWarning = (message) ->
   annotationElement = new fury.minim.elements.Annotation(message)
   annotationElement.classes.push('warning')
+  annotationElement.attributes.set('sourceMap', [
+    new fury.minim.elements.SourceMap([[0, 1]]),
+  ])
   return annotationElement
 
 

--- a/test/fixtures/api-blueprint/http-headers-multiple.apib
+++ b/test/fixtures/api-blueprint/http-headers-multiple.apib
@@ -1,0 +1,25 @@
+FORMAT: 1A
+
+# Beehive API
+
+# Honey [/honey]
+
+## Retrieve Honey [GET]
+
++ Request (application/json)
+
+    + Headers
+
+            X-Multiple: foo
+            X-Multiple: bar
+
++ Response 200 (application/json)
+
+    + Headers
+
+            Set-Cookie: session-id=123
+            Set-Cookie: likes-honey=true
+
+    + Body
+
+            {}

--- a/test/fixtures/api-blueprint/response-schema.apib
+++ b/test/fixtures/api-blueprint/response-schema.apib
@@ -4,15 +4,24 @@ FORMAT: 1A
 
 ## Honey [/honey]
 
-### Remove [DELETE]
+### With Body [POST]
 
 + Request (application/json)
 
-+ Response 200
++ Response 201
     + Body
 
             []
 
+    + Schema
+
+            {"type": "array"}
+
+### Without Body [DELETE]
+
++ Request (application/json)
+
++ Response 200
     + Schema
 
             {"type": "array"}

--- a/test/fixtures/index.coffee
+++ b/test/fixtures/index.coffee
@@ -161,6 +161,9 @@ fixtures =
   noStatus: fixture(
     apiBlueprint: fromFile('./api-blueprint/no-status.apib')
   )
+  httpHeadersMultiple: fixture(
+    apiBlueprint: fromFile('./api-blueprint/http-headers-multiple.apib')
+  )
 
   # Specific to Swagger
   produces: fixture(

--- a/test/fixtures/index.coffee
+++ b/test/fixtures/index.coffee
@@ -172,6 +172,9 @@ fixtures =
   producesCharset: fixture(
     swagger: fromFile('./swagger/produces-charset.yml')
   )
+  producesNonJSONExample: fixture(
+    swagger: fromFile('./swagger/produces-non-json-example.yml')
+  )
   consumes: fixture(
     swagger: fromFile('./swagger/consumes.yml')
   )

--- a/test/fixtures/swagger/consumes.yml
+++ b/test/fixtures/swagger/consumes.yml
@@ -4,9 +4,19 @@ info:
   title: Beehive API
 consumes:
   - application/json
+  - application/xml
 paths:
   /honey:
-    get:
+    post:
+      responses:
+        200:
+          description: pet response
+          schema:
+            $ref: '#/definitions/Bee'
+  /honey-with-override:
+    post:
+      consumes:
+        - application/json
       responses:
         200:
           description: pet response

--- a/test/fixtures/swagger/produces-non-json-example.yml
+++ b/test/fixtures/swagger/produces-non-json-example.yml
@@ -1,0 +1,16 @@
+swagger: "2.0"
+info:
+  title: Produces Non-JSON Content-Type
+  version: "1.0"
+paths:
+  /test:
+    get:
+      produces:
+        - application/json
+        - text/plain
+      responses:
+        200:
+          description: Test description
+          examples:
+            'application/json': {message: 'Hello!'}
+            'text/plain': 'Hello!'

--- a/test/integration/compile-api-blueprint-test.coffee
+++ b/test/integration/compile-api-blueprint-test.coffee
@@ -129,8 +129,7 @@ describe('compile() · API Blueprint', ->
             headers = compilationResult.transactions[i].request.headers
             contentType = headers
               .filter((header) -> header.name is 'Content-Type')
-              .map((header) -> header.value)
-              .join(', ')
+              .map((header) -> header.value)[0]
             assert.equal(contentType, requestContentType)
           )
           it("has response with status code #{responseStatusCode}", ->

--- a/test/integration/compile-api-blueprint-test.coffee
+++ b/test/integration/compile-api-blueprint-test.coffee
@@ -126,10 +126,12 @@ describe('compile() · API Blueprint', ->
             )
           )
           it("has request with Content-Type: #{requestContentType}", ->
-            assert.equal(
-              compilationResult.transactions[i].request.headers['Content-Type'].value,
-              requestContentType
-            )
+            headers = compilationResult.transactions[i].request.headers
+            contentType = headers
+              .filter((header) -> header.name is 'Content-Type')
+              .map((header) -> header.value)
+              .join(', ')
+            assert.equal(contentType, requestContentType)
           )
           it("has response with status code #{responseStatusCode}", ->
             assert.equal(
@@ -302,6 +304,58 @@ describe('compile() · API Blueprint', ->
     )
     it('assumes HTTP 200', ->
       assert.equal(compilationResult.transactions[0].response.status, '200')
+    )
+  )
+
+  describe('with multiple HTTP headers of the same name', ->
+    compilationResult = undefined
+
+    beforeEach((done) ->
+      compileFixture(fixtures.httpHeadersMultiple.apiBlueprint, (args...) ->
+        [err, compilationResult] = args
+        done(err)
+      )
+    )
+
+    it('is compiled with a single warning', ->
+      assert.equal(compilationResult.warnings.length, 1)
+    )
+    context('the warning', ->
+      it('comes from parser', ->
+        assert.equal(compilationResult.warnings[0].component, 'apiDescriptionParser')
+      )
+      it('has code', ->
+        assert.isNumber(compilationResult.warnings[0].code)
+      )
+      it('has message', ->
+        assert.include(compilationResult.warnings[0].message.toLowerCase(), 'duplicate definition')
+        assert.include(compilationResult.warnings[0].message.toLowerCase(), 'header')
+      )
+      it('has location', ->
+        assert.jsonSchema(compilationResult.warnings[0].location, locationSchema)
+      )
+      it('has no origin', ->
+        assert.isUndefined(compilationResult.warnings[0].origin)
+      )
+    )
+    it('is compiled with no errors', ->
+      assert.deepEqual(compilationResult.errors, [])
+    )
+    context('compiles a transaction', ->
+      it('with expected request headers', ->
+        assert.deepEqual(compilationResult.transactions[0].request.headers, [
+          {name: 'Content-Type', value: 'application/json'}
+          {name: 'X-Multiple', value: 'foo'}
+          {name: 'X-Multiple', value: 'bar'}
+        ])
+      )
+      it('with expected response headers', ->
+        assert.deepEqual(compilationResult.transactions[0].response.headers, [
+          {name: 'Content-Type', value: 'application/json'}
+          {name: 'Set-Cookie', value: 'session-id=123'}
+          {name: 'Set-Cookie', value: 'likes-honey=true'}
+        ])
+      )
     )
   )
 )

--- a/test/integration/compile-api-blueprint-test.coffee
+++ b/test/integration/compile-api-blueprint-test.coffee
@@ -11,7 +11,7 @@ describe('compile() · API Blueprint', ->
   describe('causing a \'missing title\' warning', ->
     compilationResult = undefined
 
-    beforeEach((done) ->
+    before((done) ->
       compileFixture(fixtures.missingTitleAnnotation.apiBlueprint, (args...) ->
         [err, compilationResult] = args
         done(err)
@@ -43,7 +43,7 @@ describe('compile() · API Blueprint', ->
 
     compilationResult = undefined
 
-    beforeEach((done) ->
+    before((done) ->
       compileFixture(fixtures.notSpecifiedInUriTemplateAnnotation.apiBlueprint, (args...) ->
         [err, compilationResult] = args
         done(err)
@@ -79,7 +79,7 @@ describe('compile() · API Blueprint', ->
       {exampleName: 'Example 2', requestContentType: 'text/plain', responseStatusCode: 415}
     ]
 
-    beforeEach((done) ->
+    before((done) ->
       stubs = {'./detect-transaction-example-numbers': detectTransactionExampleNumbers}
       compileFixture(fixtures.multipleTransactionExamples.apiBlueprint, {stubs}, (args...) ->
         [err, compilationResult] = args
@@ -127,7 +127,7 @@ describe('compile() · API Blueprint', ->
     detectTransactionExampleNumbers = sinon.spy(require('../../src/detect-transaction-example-numbers'))
     compilationResult = undefined
 
-    beforeEach((done) ->
+    before((done) ->
       stubs = {'./detect-transaction-example-numbers': detectTransactionExampleNumbers}
       compileFixture(fixtures.oneTransactionExample.apiBlueprint, {stubs}, (args...) ->
         [err, compilationResult] = args
@@ -158,7 +158,7 @@ describe('compile() · API Blueprint', ->
     compilationResult = undefined
     filename = 'apiDescription.apib'
 
-    beforeEach((done) ->
+    before((done) ->
       compileFixture(fixtures.arbitraryAction.apiBlueprint, {filename}, (args...) ->
         [err, compilationResult] = args
         done(err)
@@ -193,7 +193,7 @@ describe('compile() · API Blueprint', ->
     compilationResult = undefined
     filename = 'apiDescription.apib'
 
-    beforeEach((done) ->
+    before((done) ->
       compileFixture(fixtures.withoutSections.apiBlueprint, {filename}, (args...) ->
         [err, compilationResult] = args
         done(err)
@@ -239,7 +239,7 @@ describe('compile() · API Blueprint', ->
   describe('with different sample and default value of URI parameter', ->
     compilationResult = undefined
 
-    beforeEach((done) ->
+    before((done) ->
       compileFixture(fixtures.preferSample.apiBlueprint, (args...) ->
         [err, compilationResult] = args
         done(err)
@@ -260,7 +260,7 @@ describe('compile() · API Blueprint', ->
   describe('with response without explicit status code', ->
     compilationResult = undefined
 
-    beforeEach((done) ->
+    before((done) ->
       compileFixture(fixtures.noStatus.apiBlueprint, (args...) ->
         [err, compilationResult] = args
         done(err)
@@ -292,7 +292,7 @@ describe('compile() · API Blueprint', ->
   describe('with multiple HTTP headers of the same name', ->
     compilationResult = undefined
 
-    beforeEach((done) ->
+    before((done) ->
       compileFixture(fixtures.httpHeadersMultiple.apiBlueprint, (args...) ->
         [err, compilationResult] = args
         done(err)

--- a/test/integration/compile-api-blueprint-test.coffee
+++ b/test/integration/compile-api-blueprint-test.coffee
@@ -3,14 +3,11 @@ proxyquire = require('proxyquire').noPreserveCache()
 sinon = require('sinon')
 
 fixtures = require('../fixtures')
-createLocationSchema = require('../schemas/location')
 createCompilationResultSchema = require('../schemas/compilation-result')
 {assert, compileFixture} = require('../utils')
 
 
 describe('compile() · API Blueprint', ->
-  locationSchema = createLocationSchema()
-
   describe('causing a \'missing title\' warning', ->
     compilationResult = undefined
 
@@ -21,31 +18,22 @@ describe('compile() · API Blueprint', ->
       )
     )
 
-    it('is compiled into zero transactions', ->
-      assert.deepEqual(compilationResult.transactions, [])
+    it('produces one annotation and no transaction', ->
+      assert.jsonSchema(compilationResult, createCompilationResultSchema(
+        annotations: 1
+        transactions: 0
+      ))
     )
-    it('is compiled with one warning', ->
-      assert.equal(compilationResult.warnings.length, 1)
-    )
-    context('the warning', ->
-      it('comes from parser', ->
-        assert.equal(compilationResult.warnings[0].component, 'apiDescriptionParser')
+    context('the annotation', ->
+      it('is warning', ->
+        assert.equal(compilationResult.annotations[0].type, 'warning')
       )
-      it('has code', ->
-        assert.isNumber(compilationResult.warnings[0].code)
+      it('comes from the parser', ->
+        assert.equal(compilationResult.annotations[0].component, 'apiDescriptionParser')
       )
       it('has message', ->
-        assert.include(compilationResult.warnings[0].message.toLowerCase(), 'expected api name')
+        assert.include(compilationResult.annotations[0].message.toLowerCase(), 'expected api name')
       )
-      it('has location', ->
-        assert.jsonSchema(compilationResult.warnings[0].location, locationSchema)
-      )
-      it('has no origin', ->
-        assert.isUndefined(compilationResult.warnings[0].origin)
-      )
-    )
-    it('is compiled with no errors', ->
-      assert.deepEqual(compilationResult.errors, [])
     )
   )
 
@@ -62,32 +50,23 @@ describe('compile() · API Blueprint', ->
       )
     )
 
-    it('is compiled into expected number of transactions', ->
-      assert.equal(compilationResult.transactions.length, 1)
+    it('produces one annotation and one transaction', ->
+      assert.jsonSchema(compilationResult, createCompilationResultSchema(
+        annotations: 1
+        transactions: 1
+      ))
     )
-    it('is compiled with a single warning', ->
-      assert.equal(compilationResult.warnings.length, 1)
-    )
-    context('the warning', ->
-      it('comes from parser', ->
-        assert.equal(compilationResult.warnings[0].component, 'apiDescriptionParser')
+    context('the annotation', ->
+      it('is warning', ->
+        assert.equal(compilationResult.annotations[0].type, 'warning')
       )
-      it('has code', ->
-        assert.isNumber(compilationResult.warnings[0].code)
+      it('comes from the parser', ->
+        assert.equal(compilationResult.annotations[0].component, 'apiDescriptionParser')
       )
       it('has message', ->
-        assert.include(compilationResult.warnings[0].message.toLowerCase(), 'not found within')
-        assert.include(compilationResult.warnings[0].message.toLowerCase(), 'uri template')
+        assert.include(compilationResult.annotations[0].message.toLowerCase(), 'not found within')
+        assert.include(compilationResult.annotations[0].message.toLowerCase(), 'uri template')
       )
-      it('has location', ->
-        assert.jsonSchema(compilationResult.warnings[0].location, locationSchema)
-      )
-      it('has no origin', ->
-        assert.isUndefined(compilationResult.warnings[0].origin)
-      )
-    )
-    it('is compiled with no errors', ->
-      assert.deepEqual(compilationResult.errors, [])
     )
   )
 
@@ -108,11 +87,14 @@ describe('compile() · API Blueprint', ->
       )
     )
 
-    it('detection of transaction examples was called', ->
+    it('calls the detection of transaction examples', ->
       assert.isTrue(detectTransactionExampleNumbers.called)
     )
-    it('is compiled into expected number of transactions', ->
-      assert.equal(compilationResult.transactions.length, expected.length)
+    it("produces no annotations and #{expected.length} transactions", ->
+      assert.jsonSchema(compilationResult, createCompilationResultSchema(
+        annotations: 0
+        transactions: expected.length
+      ))
     )
     for expectations, i in expected
       do (expectations, i) ->
@@ -139,12 +121,6 @@ describe('compile() · API Blueprint', ->
             )
           )
         )
-    it('is compiled with no warnings', ->
-      assert.deepEqual(compilationResult.warnings, [])
-    )
-    it('is compiled with no errors', ->
-      assert.deepEqual(compilationResult.errors, [])
-    )
   )
 
   describe('without multiple transaction examples', ->
@@ -159,11 +135,14 @@ describe('compile() · API Blueprint', ->
       )
     )
 
-    it('detection of transaction examples was called', ->
+    it('calls the detection of transaction examples', ->
       assert.isTrue(detectTransactionExampleNumbers.called)
     )
-    it('is compiled into one transaction', ->
-      assert.equal(compilationResult.transactions.length, 1)
+    it('produces no annotations and one transaction', ->
+      assert.jsonSchema(compilationResult, createCompilationResultSchema(
+        annotations: 0
+        transactions: 1
+      ))
     )
     context('the transaction', ->
       it("is identified as part of no example in \'origin\'", ->
@@ -172,12 +151,6 @@ describe('compile() · API Blueprint', ->
       it("is identified as part of Example 1 in \'pathOrigin\'", ->
         assert.equal(compilationResult.transactions[0].pathOrigin.exampleName, 'Example 1')
       )
-    )
-    it('is compiled with no warnings', ->
-      assert.deepEqual(compilationResult.warnings, [])
-    )
-    it('is compiled with no errors', ->
-      assert.deepEqual(compilationResult.errors, [])
     )
   )
 
@@ -192,11 +165,11 @@ describe('compile() · API Blueprint', ->
       )
     )
 
-    it('is compiled with no warnings', ->
-      assert.deepEqual(compilationResult.warnings, [])
-    )
-    it('is compiled with no errors', ->
-      assert.deepEqual(compilationResult.errors, [])
+    it('produces no annotations and two transactions', ->
+      assert.jsonSchema(compilationResult, createCompilationResultSchema(
+        annotations: 0
+        transactions: 2
+      ))
     )
     context('action within a resource', ->
       it('has URI inherited from the resource', ->
@@ -227,11 +200,11 @@ describe('compile() · API Blueprint', ->
       )
     )
 
-    it('is compiled with no warnings', ->
-      assert.deepEqual(compilationResult.warnings, [])
-    )
-    it('is compiled with no errors', ->
-      assert.deepEqual(compilationResult.errors, [])
+    it('produces no annotations and one transaction', ->
+      assert.jsonSchema(compilationResult, createCompilationResultSchema(
+        annotations: 0
+        transactions: 1
+      ))
     )
     context('\'origin\'', ->
       it('uses filename as API name', ->
@@ -273,11 +246,11 @@ describe('compile() · API Blueprint', ->
       )
     )
 
-    it('is compiled with no warnings', ->
-      assert.deepEqual(compilationResult.warnings, [])
-    )
-    it('is compiled with no errors', ->
-      assert.deepEqual(compilationResult.errors, [])
+    it('produces no annotations and one transaction', ->
+      assert.jsonSchema(compilationResult, createCompilationResultSchema(
+        annotations: 0
+        transactions: 1
+      ))
     )
     it('expands the request URI using the sample value', ->
       assert.equal(compilationResult.transactions[0].request.uri, '/honey?beekeeper=Pavan')
@@ -296,10 +269,20 @@ describe('compile() · API Blueprint', ->
 
     it('produces 1 warning and 1 transaction', ->
       assert.jsonSchema(compilationResult, createCompilationResultSchema(
-        errors: 0
-        warnings: 1
+        annotations: 1
         transactions: 1
       ))
+    )
+    context('the annotation', ->
+      it('is a warning', ->
+        assert.equal(compilationResult.annotations[0].type, 'warning')
+      )
+      it('comes from the parser', ->
+        assert.equal(compilationResult.annotations[0].component, 'apiDescriptionParser')
+      )
+      it('has message about assuming the status code', ->
+        assert.include(compilationResult.annotations[0].message.toLowerCase(), 'missing response http status code, assuming')
+      )
     )
     it('assumes HTTP 200', ->
       assert.equal(compilationResult.transactions[0].response.status, '200')
@@ -316,29 +299,23 @@ describe('compile() · API Blueprint', ->
       )
     )
 
-    it('is compiled with a single warning', ->
-      assert.equal(compilationResult.warnings.length, 1)
+    it('produces 1 warning and 1 transaction', ->
+      assert.jsonSchema(compilationResult, createCompilationResultSchema(
+        annotations: 1
+        transactions: 1
+      ))
     )
-    context('the warning', ->
-      it('comes from parser', ->
-        assert.equal(compilationResult.warnings[0].component, 'apiDescriptionParser')
+    context('the annotation', ->
+      it('is a warning', ->
+        assert.equal(compilationResult.annotations[0].type, 'warning')
       )
-      it('has code', ->
-        assert.isNumber(compilationResult.warnings[0].code)
+      it('comes from the parser', ->
+        assert.equal(compilationResult.annotations[0].component, 'apiDescriptionParser')
       )
-      it('has message', ->
-        assert.include(compilationResult.warnings[0].message.toLowerCase(), 'duplicate definition')
-        assert.include(compilationResult.warnings[0].message.toLowerCase(), 'header')
+      it('has message about duplicate header names', ->
+        assert.include(compilationResult.annotations[0].message.toLowerCase(), 'duplicate definition')
+        assert.include(compilationResult.annotations[0].message.toLowerCase(), 'header')
       )
-      it('has location', ->
-        assert.jsonSchema(compilationResult.warnings[0].location, locationSchema)
-      )
-      it('has no origin', ->
-        assert.isUndefined(compilationResult.warnings[0].origin)
-      )
-    )
-    it('is compiled with no errors', ->
-      assert.deepEqual(compilationResult.errors, [])
     )
     context('compiles a transaction', ->
       it('with expected request headers', ->

--- a/test/integration/compile-swagger-test.coffee
+++ b/test/integration/compile-swagger-test.coffee
@@ -3,6 +3,7 @@ sinon = require('sinon')
 fixtures = require('../fixtures')
 {assert, compileFixture} = require('../utils')
 createCompilationResultSchema = require('../schemas/compilation-result')
+createAnnotationSchema = require('../schemas/annotation')
 
 
 describe('compile() · Swagger', ->
@@ -16,23 +17,18 @@ describe('compile() · Swagger', ->
       )
     )
 
-    it('produces one annotation and no transaction', ->
+    it('produces one annotation and no transactions', ->
       assert.jsonSchema(compilationResult, createCompilationResultSchema(
         annotations: 1
         transactions: 0
       ))
     )
-    context('the annotation', ->
-      it('is error', ->
-        assert.equal(compilationResult.annotations[0].type, 'error')
-      )
-      it('comes from the parser', ->
-        assert.equal(compilationResult.annotations[0].component, 'apiDescriptionParser')
-      )
-      it('has message', ->
-        assert.include(compilationResult.annotations[0].message.toLowerCase(), 'no corresponding')
-        assert.include(compilationResult.annotations[0].message.toLowerCase(), 'in the path string')
-      )
+    it('produces error about parameter not being in the URI Template', ->
+      assert.jsonSchema(compilationResult.annotations[0], createAnnotationSchema(
+        type: 'error'
+        component: 'apiDescriptionParser'
+        message: /no corresponding.+in the path string/
+      ))
     )
   )
 
@@ -46,9 +42,8 @@ describe('compile() · Swagger', ->
       )
     )
 
-    it('produces no annotations and two transactions', ->
+    it('produces two transactions', ->
       assert.jsonSchema(compilationResult, createCompilationResultSchema(
-        annotations: 0
         transactions: 2
       ))
     )
@@ -81,9 +76,8 @@ describe('compile() · Swagger', ->
       )
     )
 
-    it('produces no annotations and two transactions', ->
+    it('produces two transactions', ->
       assert.jsonSchema(compilationResult, createCompilationResultSchema(
-        annotations: 0
         transactions: 2
       ))
     )
@@ -116,9 +110,8 @@ describe('compile() · Swagger', ->
       )
     )
 
-    it('produces no annotations and two transactions', ->
+    it('produces two transactions', ->
       assert.jsonSchema(compilationResult, createCompilationResultSchema(
-        annotations: 0
         transactions: 2
       ))
     )
@@ -151,9 +144,8 @@ describe('compile() · Swagger', ->
       )
     )
 
-    it('produces no annotations and two transactions', ->
+    it('produces two transactions', ->
       assert.jsonSchema(compilationResult, createCompilationResultSchema(
-        annotations: 0
         transactions: 3
       ))
     )
@@ -188,9 +180,8 @@ describe('compile() · Swagger', ->
     it('does not call the detection of transaction examples', ->
       assert.isFalse(detectTransactionExampleNumbers.called)
     )
-    it("produces no annotations and #{expectedStatusCodes.length} transactions", ->
+    it("produces #{expectedStatusCodes.length} transactions", ->
       assert.jsonSchema(compilationResult, createCompilationResultSchema(
-        annotations: 0
         transactions: expectedStatusCodes.length
       ))
     )
@@ -232,9 +223,8 @@ describe('compile() · Swagger', ->
       )
     )
 
-    it('produces no annotations and 2 transactions', ->
+    it('produces two transactions', ->
       assert.jsonSchema(compilationResult, createCompilationResultSchema(
-        annotations: 0
         transactions: 2
       ))
     )
@@ -250,9 +240,8 @@ describe('compile() · Swagger', ->
       )
     )
 
-    it('produces no annotations and 1 transaction', ->
+    it('produces one transaction', ->
       assert.jsonSchema(compilationResult, createCompilationResultSchema(
-        annotations: 0
         transactions: 1
       ))
     )
@@ -268,26 +257,19 @@ describe('compile() · Swagger', ->
       )
     )
 
-    it('produces 2 annotations and 2 transactions', ->
+    it('produces two annotations and two transactions', ->
       assert.jsonSchema(compilationResult, createCompilationResultSchema(
         annotations: 2
         transactions: 2
       ))
     )
-    context('the annotations', ->
-      it('are warnings', ->
-        compilationResult.annotations.forEach((annotation) ->
-          assert.equal(annotation.type, 'warning')
-        )
-      )
-      it('are from parser', ->
-        compilationResult.annotations.forEach((annotation) ->
-          assert.equal(annotation.component, 'apiDescriptionParser')
-        )
-      )
-      it('are about the default response being unsupported', ->
-        compilationResult.annotations.forEach((annotation) ->
-          assert.equal(annotation.message.toLowerCase(), 'default response is not yet supported')
+    it('produces warnings about the default response being unsupported', ->
+      assert.jsonSchema(compilationResult.annotations,
+        type: 'array'
+        items: createAnnotationSchema(
+          type: 'warning'
+          component: 'apiDescriptionParser'
+          message: 'Default response is not yet supported'
         )
       )
     )

--- a/test/integration/compile-swagger-test.coffee
+++ b/test/integration/compile-swagger-test.coffee
@@ -9,7 +9,7 @@ describe('compile() · Swagger', ->
   describe('causing a \'not specified in URI Template\' error', ->
     compilationResult = undefined
 
-    beforeEach((done) ->
+    before((done) ->
       compileFixture(fixtures.notSpecifiedInUriTemplateAnnotation.swagger, (args...) ->
         [err, compilationResult] = args
         done(err)
@@ -39,7 +39,7 @@ describe('compile() · Swagger', ->
   describe('with \'produces\' containing JSON media type', ->
     compilationResult = undefined
 
-    beforeEach((done) ->
+    before((done) ->
       compileFixture(fixtures.produces.swagger, (args...) ->
         [err, compilationResult] = args
         done(err)
@@ -74,7 +74,7 @@ describe('compile() · Swagger', ->
   describe('with \'produces\' containing JSON media type with parameters', ->
     compilationResult = undefined
 
-    beforeEach((done) ->
+    before((done) ->
       compileFixture(fixtures.producesCharset.swagger, (args...) ->
         [err, compilationResult] = args
         done(err)
@@ -109,7 +109,7 @@ describe('compile() · Swagger', ->
   describe('with \'produces\' containing a non-JSON media type with an example', ->
     compilationResult = undefined
 
-    beforeEach((done) ->
+    before((done) ->
       compileFixture(fixtures.producesNonJSONExample.swagger, (args...) ->
         [err, compilationResult] = args
         done(err)
@@ -144,7 +144,7 @@ describe('compile() · Swagger', ->
   describe('with \'consumes\'', ->
     compilationResult = undefined
 
-    beforeEach((done) ->
+    before((done) ->
       compileFixture(fixtures.consumes.swagger, (args...) ->
         [err, compilationResult] = args
         done(err)
@@ -177,7 +177,7 @@ describe('compile() · Swagger', ->
     detectTransactionExampleNumbers = sinon.spy(require('../../src/detect-transaction-example-numbers'))
     expectedStatusCodes = [200, 400, 500]
 
-    beforeEach((done) ->
+    before((done) ->
       stubs = {'./detect-transaction-example-numbers': detectTransactionExampleNumbers}
       compileFixture(fixtures.multipleResponses.swagger, {filename, stubs}, (args...) ->
         [err, compilationResult] = args
@@ -225,7 +225,7 @@ describe('compile() · Swagger', ->
   describe('with \'securityDefinitions\' and multiple responses', ->
     compilationResult = undefined
 
-    beforeEach((done) ->
+    before((done) ->
       compileFixture(fixtures.securityDefinitionsMultipleResponses.swagger, (args...) ->
         [err, compilationResult] = args
         done(err)
@@ -243,7 +243,7 @@ describe('compile() · Swagger', ->
   describe('with \'securityDefinitions\' containing transitions', ->
     compilationResult = undefined
 
-    beforeEach((done) ->
+    before((done) ->
       compileFixture(fixtures.securityDefinitionsTransitions.swagger, (args...) ->
         [err, compilationResult] = args
         done(err)
@@ -261,7 +261,7 @@ describe('compile() · Swagger', ->
   describe('with default response (without explicit status code)', ->
     compilationResult = undefined
 
-    beforeEach((done) ->
+    before((done) ->
       compileFixture(fixtures.defaultResponse.swagger, (args...) ->
         [err, compilationResult] = args
         done(err)

--- a/test/integration/compile-swagger-test.coffee
+++ b/test/integration/compile-swagger-test.coffee
@@ -93,14 +93,14 @@ describe('compile() · Swagger', ->
     )
     context('compiles a transaction', ->
       it('with expected request headers', ->
-        assert.deepEqual(compilationResult.transactions[0].request.headers, {
-          'Accept': {value: 'application/json; charset=utf-8'}
-        })
+        assert.deepEqual(compilationResult.transactions[0].request.headers, [
+          {name: 'Accept', value: 'application/json; charset=utf-8'}
+        ])
       )
       it('with expected response headers', ->
-        assert.deepEqual(compilationResult.transactions[0].response.headers, {
-          'Content-Type': {value: 'application/json; charset=utf-8'}
-        })
+        assert.deepEqual(compilationResult.transactions[0].response.headers, [
+          {name: 'Content-Type', value: 'application/json; charset=utf-8'}
+        ])
       )
     )
   )
@@ -155,7 +155,10 @@ describe('compile() · Swagger', ->
     )
     it('skips non-JSON media types in \'produces\'', ->
       compilationResult.transactions.forEach((transaction) ->
-        assert.equal(transaction.response.headers['Content-Type'].value, 'application/json')
+        contentType = transaction.response.headers
+          .filter((header) -> header.name.toLowerCase() is 'content-type')
+          .map((header) -> header.value)[0]
+        assert.equal(contentType, 'application/json')
       )
     )
     it('is compiled with no warnings', ->

--- a/test/integration/compile-swagger-test.coffee
+++ b/test/integration/compile-swagger-test.coffee
@@ -63,14 +63,14 @@ describe('compile() · Swagger', ->
     )
     context('compiles a transaction', ->
       it('with expected request headers', ->
-        assert.deepEqual(compilationResult.transactions[0].request.headers, {
-          'Accept': {value: 'application/json'}
-        })
+        assert.deepEqual(compilationResult.transactions[0].request.headers, [
+          {name: 'Accept', value: 'application/json'}
+        ])
       )
       it('with expected response headers', ->
-        assert.deepEqual(compilationResult.transactions[0].response.headers, {
-          'Content-Type': {value: 'application/json'}
-        })
+        assert.deepEqual(compilationResult.transactions[0].response.headers, [
+          {name: 'Content-Type', value: 'application/json'}
+        ])
       )
     )
   )
@@ -123,12 +123,12 @@ describe('compile() · Swagger', ->
     )
     context('compiles a transaction', ->
       it('with expected request headers', ->
-        assert.deepEqual(compilationResult.transactions[0].request.headers, {
-          'Content-Type': {value: 'application/json'}
-        })
+        assert.deepEqual(compilationResult.transactions[0].request.headers, [
+          {name: 'Content-Type', value: 'application/json'}
+        ])
       )
       it('with expected response headers', ->
-        assert.deepEqual(compilationResult.transactions[0].response.headers, {})
+        assert.deepEqual(compilationResult.transactions[0].response.headers, [])
       )
     )
   )

--- a/test/integration/compile-test.coffee
+++ b/test/integration/compile-test.coffee
@@ -661,16 +661,16 @@ describe('compile() · all API description formats', ->
       )
       context('compiles a transaction', ->
         it('with expected request headers', ->
-          assert.deepEqual(compilationResult.transactions[0].request.headers, {
-            'Content-Type': {value: 'application/json'}
-            'Accept': {value: 'application/json'}
-          })
+          assert.deepEqual(compilationResult.transactions[0].request.headers, [
+            {name: 'Content-Type', value: 'application/json'}
+            {name: 'Accept', value: 'application/json'}
+          ])
         )
         it('with expected response headers', ->
-          assert.deepEqual(compilationResult.transactions[0].response.headers, {
-            'Content-Type': {value: 'application/json'}
-            'X-Test': {value: 'Adam'}
-          })
+          assert.deepEqual(compilationResult.transactions[0].response.headers, [
+            {name: 'Content-Type', value: 'application/json'}
+            {name: 'X-Test', value: 'Adam'}
+          ])
         )
       )
     )

--- a/test/integration/compile-test.coffee
+++ b/test/integration/compile-test.coffee
@@ -45,30 +45,18 @@ describe('compile() · all API description formats', ->
         )
       )
 
-      it('is compiled into zero transactions', ->
-        assert.deepEqual(compilationResult.transactions, [])
+      it('produces one annotation and no transactions', ->
+        assert.jsonSchema(compilationResult, createCompilationResultSchema(
+          annotations: 1
+          transactions: 0
+        ))
       )
-      it('is compiled with no warnings', ->
-        assert.deepEqual(compilationResult.warnings, [])
-      )
-      it('is compiled with an error', ->
-        assert.equal(compilationResult.errors.length, 1)
-      )
-      context('the error', ->
-        it('comes from parser', ->
-          assert.equal(compilationResult.errors[0].component, 'apiDescriptionParser')
+      context('the annotation', ->
+        it('is error', ->
+          assert.equal(compilationResult.annotations[0].type, 'error')
         )
-        it('has code', ->
-          assert.isNumber(compilationResult.errors[0].code)
-        )
-        it('has message', ->
-          assert.isString(compilationResult.errors[0].message)
-        )
-        it('has location', ->
-          assert.jsonSchema(compilationResult.errors[0].location, locationSchema)
-        )
-        it('has no origin', ->
-          assert.isUndefined(compilationResult.errors[0].origin)
+        it('comes from the parser', ->
+          assert.equal(compilationResult.annotations[0].component, 'apiDescriptionParser')
         )
       )
     )
@@ -91,33 +79,22 @@ describe('compile() · all API description formats', ->
         )
       )
 
-      it('is compiled into zero transactions', ->
-        assert.deepEqual(compilationResult.transactions, [])
+      it('produces some annotations and no transactions', ->
+        assert.jsonSchema(compilationResult, createCompilationResultSchema(
+          annotations: true
+          transactions: 0
+        ))
       )
       it('is compiled with maximum one warning from parser', ->
-        assert.isAtMost(compilationResult.warnings.length, 1)
-        if compilationResult.warnings.length
-          assert.equal(compilationResult.warnings[0].component, 'apiDescriptionParser')
+        warnings = compilationResult.annotations.filter((ann) -> ann.type is 'warning')
+        assert.isAtMost(warnings.length, 1)
+        assert.equal(warnings[0].component, 'apiDescriptionParser') if warnings.length
       )
-      it('is compiled with one error', ->
-        assert.equal(compilationResult.errors.length, 1)
-      )
-      context('the error', ->
-        it('comes from URI expansion', ->
-          assert.equal(compilationResult.errors[0].component, 'uriTemplateExpansion')
-        )
-        it('has no code', ->
-          assert.isUndefined(compilationResult.errors[0].code)
-        )
-        it('has message', ->
-          assert.include(compilationResult.errors[0].message.toLowerCase(), 'failed to parse uri template')
-        )
-        it('has location', ->
-          assert.jsonSchema(compilationResult.errors[0].location, locationSchema)
-        )
-        it('has origin', ->
-          assert.jsonSchema(compilationResult.errors[0].origin, originSchema)
-        )
+      it('is compiled with one error from URI expansion', ->
+        errors = compilationResult.annotations.filter((ann) -> ann.type is 'error')
+        assert.equal(errors.length, 1)
+        assert.equal(errors[0].component, 'uriTemplateExpansion') if errors.length
+        assert.include(errors[0].message.toLowerCase(), 'failed to parse uri template')
       )
     )
   )
@@ -140,43 +117,33 @@ describe('compile() · all API description formats', ->
         )
       )
 
-      it('is compiled into zero transactions', ->
-        assert.deepEqual(compilationResult.transactions, [])
+      it('produces some annotations and no transactions', ->
+        assert.jsonSchema(compilationResult, createCompilationResultSchema(
+          annotations: true
+          transactions: 0
+        ))
       )
       it('is compiled with maximum two warnings', ->
-        assert.isAtMost(compilationResult.warnings.length, 2)
+        warnings = compilationResult.annotations.filter((ann) -> ann.type is 'warning')
+        assert.isAtMost(warnings.length, 2)
       )
-      it('there is maximum one warning from parser', ->
-        warnings = compilationResult.warnings.filter((warning) ->
-          warning.component is 'apiDescriptionParser'
+      it('is compiled with maximum one warning from parser', ->
+        warnings = compilationResult.annotations.filter((ann) ->
+          ann.type is 'warning' and ann.component is 'apiDescriptionParser'
         )
         assert.isAtMost(warnings.length, 1)
       )
-      it('there is one warning from URI expansion', ->
-        warnings = compilationResult.warnings.filter((warning) ->
-          warning.component is 'uriTemplateExpansion'
+      it('is compiled with one warning from URI expansion', ->
+        warnings = compilationResult.annotations.filter((ann) ->
+          ann.type is 'warning' and ann.component is 'uriTemplateExpansion'
         )
         assert.equal(warnings.length, 1)
       )
-      it('is compiled with one error', ->
-        assert.equal(compilationResult.errors.length, 1)
-      )
-      context('the error', ->
-        it('comes from URI parameters validation', ->
-          assert.equal(compilationResult.errors[0].component, 'parametersValidation')
-        )
-        it('has no code', ->
-          assert.isUndefined(compilationResult.errors[0].code)
-        )
-        it('has message', ->
-          assert.include(compilationResult.errors[0].message.toLowerCase(), 'no example')
-        )
-        it('has location', ->
-          assert.jsonSchema(compilationResult.errors[0].location, locationSchema)
-        )
-        it('has origin', ->
-          assert.jsonSchema(compilationResult.errors[0].origin, originSchema)
-        )
+      it('is compiled with one error from URI parameters validation', ->
+        errors = compilationResult.annotations.filter((ann) -> ann.type is 'error')
+        assert.equal(errors.length, 1)
+        assert.equal(errors[0].component, 'parametersValidation')
+        assert.include(errors[0].message.toLowerCase(), 'no example')
       )
     )
   )
@@ -192,36 +159,21 @@ describe('compile() · all API description formats', ->
         )
       )
 
-      it('is compiled into expected number of transactions', ->
-        assert.equal(compilationResult.transactions.length, 1)
+      it('produces some annotations and one transaction', ->
+        assert.jsonSchema(compilationResult, createCompilationResultSchema(
+          annotations: true
+          transactions: 1
+        ))
       )
-      it('is compiled with some warnings', ->
-        assert.ok(compilationResult.warnings.length)
-      )
-      context('the warnings', ->
-        it('comes from parser', ->
-          for warning in compilationResult.warnings
-            assert.equal(warning.component, 'apiDescriptionParser')
+      context('the annotations', ->
+        it('are warnings', ->
+          for ann in compilationResult.annotations
+            assert.equal(ann.type, 'warning')
         )
-        it('have code', ->
-          for warning in compilationResult.warnings
-            assert.isNumber(warning.code)
+        it('come from parser', ->
+          for ann in compilationResult.annotations
+            assert.equal(ann.component, 'apiDescriptionParser')
         )
-        it('have message', ->
-          for warning in compilationResult.warnings
-            assert.isString(warning.message)
-        )
-        it('have location', ->
-          for warning in compilationResult.warnings
-            assert.jsonSchema(warning.location, locationSchema)
-        )
-        it('have no origin', ->
-          for warning in compilationResult.warnings
-            assert.isUndefined(warning.origin)
-        )
-      )
-      it('is compiled with no errors', ->
-        assert.deepEqual(compilationResult.errors, [])
       )
     )
   )
@@ -252,36 +204,25 @@ describe('compile() · all API description formats', ->
         )
       )
 
-      it('is compiled into some transactions', ->
-        assert.ok(compilationResult.transactions.length)
+      it('produces some annotations and some transactions', ->
+        assert.jsonSchema(compilationResult, createCompilationResultSchema(
+          annotations: true
+          transactions: true
+        ))
       )
-      it('is compiled with some warnings', ->
-        assert.ok(compilationResult.warnings.length)
-      )
-      context('the warnings', ->
+      context('the annotations', ->
+        it('are warnings', ->
+          for ann in compilationResult.annotations
+            assert.equal(ann.type, 'warning')
+        )
         it('come from URI expansion', ->
-          for warning in compilationResult.warnings
-            assert.equal(warning.component, 'uriTemplateExpansion')
+          for ann in compilationResult.annotations
+            assert.equal(ann.component, 'uriTemplateExpansion')
         )
-        it('have no code', ->
-          for warning in compilationResult.warnings
-            assert.isUndefined(warning.code)
+        it('have the expected message', ->
+          for ann in compilationResult.annotations
+            assert.include(ann.message, message)
         )
-        it('have message', ->
-          for warning in compilationResult.warnings
-            assert.include(warning.message, message)
-        )
-        it('have location', ->
-          for warning in compilationResult.warnings
-            assert.jsonSchema(warning.location, locationSchema)
-        )
-        it('have origin', ->
-          for warning in compilationResult.warnings
-            assert.jsonSchema(warning.origin, originSchema)
-        )
-      )
-      it('is compiled with no errors', ->
-        assert.deepEqual(compilationResult.errors, [])
       )
     )
   )
@@ -306,32 +247,21 @@ describe('compile() · all API description formats', ->
         )
       )
 
-      it('is compiled into zero transactions', ->
-        assert.deepEqual(compilationResult.transactions, [])
+      it('produces one annotation and no transactions', ->
+        assert.jsonSchema(compilationResult, createCompilationResultSchema(
+          annotations: 2
+          transactions: 0
+        ))
       )
-      it('is compiled with one warning', ->
-        assert.equal(compilationResult.warnings.length, 1)
-      )
-      context('the warning', ->
-        it('comes from URI expansion', ->
-          assert.equal(compilationResult.warnings[0].component, 'uriTemplateExpansion')
-        )
-        it('has no code', ->
-          assert.isUndefined(compilationResult.warnings[0].code)
-        )
-        it('has message', ->
-          assert.include(compilationResult.warnings[0].message.toLowerCase(), 'ambiguous')
-        )
-        it('has location', ->
-          assert.jsonSchema(compilationResult.warnings[0].location, locationSchema)
-        )
-        it('has origin', ->
-          assert.jsonSchema(compilationResult.warnings[0].origin, originSchema)
-        )
+      it('is compiled with one warning from URI expansion', ->
+        warnings = compilationResult.annotations.filter((ann) -> ann.type is 'warning')
+        assert.equal(warnings.length, 1)
+        assert.equal(warnings[0].component, 'uriTemplateExpansion')
       )
       it('is compiled with one error from URI parameters validation', ->
-        assert.equal(compilationResult.errors.length, 1)
-        assert.equal(compilationResult.errors[0].component, 'parametersValidation')
+        errors = compilationResult.annotations.filter((ann) -> ann.type is 'error')
+        assert.equal(errors.length, 1)
+        assert.equal(errors[0].component, 'parametersValidation')
       )
     )
   )
@@ -358,36 +288,25 @@ describe('compile() · all API description formats', ->
         )
       )
 
-      it('is compiled into some transactions', ->
-        assert.ok(compilationResult.transactions.length)
+      it('produces some annotations and some transactions', ->
+        assert.jsonSchema(compilationResult, createCompilationResultSchema(
+          annotations: true
+          transactions: true
+        ))
       )
-      it('is compiled with some warnings', ->
-        assert.ok(compilationResult.warnings.length)
-      )
-      context('the warnings', ->
+      context('the annotations', ->
+        it('are warnings', ->
+          for ann in compilationResult.annotations
+            assert.equal(ann.type, 'warning')
+        )
         it('come from URI parameters validation', ->
-          for warning in compilationResult.warnings
-            assert.equal(warning.component, 'parametersValidation')
+          for ann in compilationResult.annotations
+            assert.equal(ann.component, 'parametersValidation')
         )
-        it('have no code', ->
-          for warning in compilationResult.warnings
-            assert.isUndefined(warning.code)
+        it('have the expected message', ->
+          for ann in compilationResult.annotations
+            assert.include(ann.message, message)
         )
-        it('have message', ->
-          for warning in compilationResult.warnings
-            assert.include(warning.message, message)
-        )
-        it('have location', ->
-          for warning in compilationResult.warnings
-            assert.jsonSchema(warning.location, locationSchema)
-        )
-        it('have origin', ->
-          for warning in compilationResult.warnings
-            assert.jsonSchema(warning.origin, originSchema)
-        )
-      )
-      it('is compiled with no errors', ->
-        assert.deepEqual(compilationResult.errors, [])
       )
     )
   )
@@ -403,11 +322,11 @@ describe('compile() · all API description formats', ->
         )
       )
 
-      it('is compiled with no warnings', ->
-        assert.deepEqual(compilationResult.warnings, [])
-      )
-      it('is compiled with no errors', ->
-        assert.deepEqual(compilationResult.errors, [])
+      it('produces no annotations and one transaction', ->
+        assert.jsonSchema(compilationResult, createCompilationResultSchema(
+          annotations: 0
+          transactions: 1
+        ))
       )
       it('expands the request URI with the first enum value', ->
         assert.equal(compilationResult.transactions[0].request.uri, '/honey?beekeeper=Adam')
@@ -426,11 +345,11 @@ describe('compile() · all API description formats', ->
         )
       )
 
-      it('is compiled with no warnings', ->
-        assert.deepEqual(compilationResult.warnings, [])
-      )
-      it('is compiled with no errors', ->
-        assert.deepEqual(compilationResult.errors, [])
+      it('produces no annotations and one transaction', ->
+        assert.jsonSchema(compilationResult, createCompilationResultSchema(
+          annotations: 0
+          transactions: 1
+        ))
       )
       it('expands the request URI with the example value', ->
         assert.equal(compilationResult.transactions[0].request.uri, '/honey?beekeeper=Honza')
@@ -455,32 +374,23 @@ describe('compile() · all API description formats', ->
         )
       )
 
-      it('is compiled into one transaction', ->
-        assert.equal(compilationResult.transactions.length, 1)
+      it('produces some annotations and one transaction', ->
+        assert.jsonSchema(compilationResult, createCompilationResultSchema(
+          annotations: true
+          transactions: 1
+        ))
       )
       it('is compiled with maximum one warning from parser', ->
-        if compilationResult.warnings.length
-          assert.equal(compilationResult.warnings[0].component, 'apiDescriptionParser')
+        warnings = compilationResult.annotations.filter((ann) ->
+          ann.type is 'warning' and ann.component is 'apiDescriptionParser'
+        )
+        assert.isAtMost(warnings.length, 1)
       )
-      it('is compiled with one error', ->
-        assert.equal(compilationResult.errors.length, 1)
-      )
-      context('the error', ->
-        it('comes from URI parameters validation', ->
-          assert.equal(compilationResult.errors[0].component, 'parametersValidation')
-        )
-        it('has no code', ->
-          assert.isUndefined(compilationResult.errors[0].code)
-        )
-        it('has message', ->
-          assert.include(compilationResult.errors[0].message.toLowerCase(), 'example value is not one of enum values')
-        )
-        it('has location', ->
-          assert.jsonSchema(compilationResult.errors[0].location, locationSchema)
-        )
-        it('has origin', ->
-          assert.jsonSchema(compilationResult.errors[0].origin, originSchema)
-        )
+      it('is compiled with one error from URI parameters validation', ->
+        errors = compilationResult.annotations.filter((ann) -> ann.type is 'error')
+        assert.equal(errors.length, 1)
+        assert.equal(errors[0].component, 'parametersValidation')
+        assert.include(errors[0].message.toLowerCase(), 'example value is not one of enum values')
       )
       it('expands the request URI with the example value', ->
         assert.equal(compilationResult.transactions[0].request.uri, '/honey?beekeeper=Pavan')
@@ -499,11 +409,11 @@ describe('compile() · all API description formats', ->
         )
       )
 
-      it('is compiled with no warnings', ->
-        assert.deepEqual(compilationResult.warnings, [])
-      )
-      it('is compiled with no errors', ->
-        assert.deepEqual(compilationResult.errors, [])
+      it('produces no annotations and one transaction', ->
+        assert.jsonSchema(compilationResult, createCompilationResultSchema(
+          annotations: 0
+          transactions: 1
+        ))
       )
       it('expands the request URI with the example value', ->
         assert.equal(compilationResult.transactions[0].request.uri, '/honey?beekeeper=Honza&flavour=spicy')
@@ -522,19 +432,30 @@ describe('compile() · all API description formats', ->
         )
       )
 
-      it('is compiled with no warnings', ->
-        assert.deepEqual(compilationResult.warnings, [])
+      it('produces no annotations and one transaction', ->
+        assert.jsonSchema(compilationResult, createCompilationResultSchema(
+          annotations: 0
+          transactions: 2
+        ))
       )
-      it('is compiled with no errors', ->
-        assert.deepEqual(compilationResult.errors, [])
+      context('the first transaction', ->
+        it('has the body in response data', ->
+          assert.ok(compilationResult.transactions[0].response.body)
+          assert.doesNotThrow( -> JSON.parse(compilationResult.transactions[0].response.body))
+        )
+        it('has the schema in response data', ->
+          assert.ok(compilationResult.transactions[0].response.schema)
+          assert.doesNotThrow( -> JSON.parse(compilationResult.transactions[0].response.schema))
+        )
       )
-      it('provides the body in response data', ->
-        assert.ok(compilationResult.transactions[0].response.body)
-        assert.doesNotThrow( -> JSON.parse(compilationResult.transactions[0].response.body))
-      )
-      it('provides the schema in response data', ->
-        assert.ok(compilationResult.transactions[0].response.schema)
-        assert.doesNotThrow( -> JSON.parse(compilationResult.transactions[0].response.schema))
+      context('the second transaction', ->
+        it('has no body in response data', ->
+          assert.notOk(compilationResult.transactions[1].response.body)
+        )
+        it('has the schema in response data', ->
+          assert.ok(compilationResult.transactions[1].response.schema)
+          assert.doesNotThrow( -> JSON.parse(compilationResult.transactions[1].response.schema))
+        )
       )
     )
   )
@@ -550,11 +471,11 @@ describe('compile() · all API description formats', ->
         )
       )
 
-      it('is compiled with no warnings', ->
-        assert.deepEqual(compilationResult.warnings, [])
-      )
-      it('is compiled with no errors', ->
-        assert.deepEqual(compilationResult.errors, [])
+      it('produces no annotations and one transaction', ->
+        assert.jsonSchema(compilationResult, createCompilationResultSchema(
+          annotations: 0
+          transactions: 1
+        ))
       )
       it('expands the request URI using correct inheritance cascade', ->
         assert.equal(compilationResult.transactions[0].request.uri, '/honey?beekeeper=Honza&amount=42')
@@ -573,11 +494,11 @@ describe('compile() · all API description formats', ->
         )
       )
 
-      it('is compiled with no warnings', ->
-        assert.deepEqual(compilationResult.warnings, [])
-      )
-      it('is compiled with no errors', ->
-        assert.deepEqual(compilationResult.errors, [])
+      it('produces no annotations and one transaction', ->
+        assert.jsonSchema(compilationResult, createCompilationResultSchema(
+          annotations: 0
+          transactions: 1
+        ))
       )
       it('expands the request URI using the default value', ->
         assert.equal(compilationResult.transactions[0].request.uri, '/honey?beekeeper=Adam')
@@ -596,48 +517,30 @@ describe('compile() · all API description formats', ->
         )
       )
 
-      it('expands the request URI using the default value', ->
-        assert.equal(compilationResult.transactions[0].request.uri, '/honey?beekeeper=Honza')
+      it('produces some annotations and one transaction', ->
+        assert.jsonSchema(compilationResult, createCompilationResultSchema(
+          annotations: true
+          transactions: 1
+        ))
       )
-      it('is compiled with no errors', ->
-        assert.deepEqual(compilationResult.errors, [])
+      it('is compiled with maximum three annotations', ->
+        assert.isAtMost(compilationResult.annotations.length, 3)
       )
-      it('is compiled with maximum two warnings', ->
-        assert.isAtMost(compilationResult.warnings.length, 2)
-      )
-      it('there is maximum one warning from parser', ->
-        warnings = compilationResult.warnings.filter((warning) ->
-          warning.component is 'apiDescriptionParser'
+      it('is compiled with maximum one warning from parser', ->
+        warnings = compilationResult.annotations.filter((ann) ->
+          ann.type is 'warning' and ann.component is 'apiDescriptionParser'
         )
         assert.isAtMost(warnings.length, 1)
       )
-      it('there is one warning from URI expansion', ->
-        warnings = compilationResult.warnings.filter((warning) ->
-          warning.component is 'uriTemplateExpansion'
+      it('is compiled with one warning from URI expansion', ->
+        warnings = compilationResult.annotations.filter((ann) ->
+          ann.type is 'warning' and ann.component is 'uriTemplateExpansion'
         )
         assert.equal(warnings.length, 1)
+        assert.include(warnings[0].message.toLowerCase(), 'default value for a required parameter')
       )
-      context('the last warning', ->
-        it('comes from URI expansion', ->
-          lastWarning = compilationResult.warnings[compilationResult.warnings.length - 1]
-          assert.equal(lastWarning.component, 'uriTemplateExpansion')
-        )
-        it('has no code', ->
-          lastWarning = compilationResult.warnings[compilationResult.warnings.length - 1]
-          assert.isUndefined(lastWarning.code)
-        )
-        it('has message', ->
-          lastWarning = compilationResult.warnings[compilationResult.warnings.length - 1]
-          assert.include(lastWarning.message.toLowerCase(), 'default value for a required parameter')
-        )
-        it('has location', ->
-          lastWarning = compilationResult.warnings[compilationResult.warnings.length - 1]
-          assert.jsonSchema(lastWarning.location, locationSchema)
-        )
-        it('has origin', ->
-          lastWarning = compilationResult.warnings[compilationResult.warnings.length - 1]
-          assert.jsonSchema(lastWarning.origin, originSchema)
-        )
+      it('expands the request URI using the default value', ->
+        assert.equal(compilationResult.transactions[0].request.uri, '/honey?beekeeper=Honza')
       )
     )
   )
@@ -653,25 +556,23 @@ describe('compile() · all API description formats', ->
         )
       )
 
-      it('is compiled with no warnings', ->
-        assert.deepEqual(compilationResult.warnings, [])
+      it('produces no annotations and one transaction', ->
+        assert.jsonSchema(compilationResult, createCompilationResultSchema(
+          annotations: 0
+          transactions: 1
+        ))
       )
-      it('is compiled with no errors', ->
-        assert.deepEqual(compilationResult.errors, [])
+      it('produces expected request headers', ->
+        assert.deepEqual(compilationResult.transactions[0].request.headers, [
+          {name: 'Content-Type', value: 'application/json'}
+          {name: 'Accept', value: 'application/json'}
+        ])
       )
-      context('compiles a transaction', ->
-        it('with expected request headers', ->
-          assert.deepEqual(compilationResult.transactions[0].request.headers, [
-            {name: 'Content-Type', value: 'application/json'}
-            {name: 'Accept', value: 'application/json'}
-          ])
-        )
-        it('with expected response headers', ->
-          assert.deepEqual(compilationResult.transactions[0].response.headers, [
-            {name: 'Content-Type', value: 'application/json'}
-            {name: 'X-Test', value: 'Adam'}
-          ])
-        )
+      it('produces expected response headers', ->
+        assert.deepEqual(compilationResult.transactions[0].response.headers, [
+          {name: 'Content-Type', value: 'application/json'}
+          {name: 'X-Test', value: 'Adam'}
+        ])
       )
     )
   )
@@ -729,7 +630,7 @@ describe('compile() · all API description formats', ->
               {name: 'Content-Type', value: mediaType}
             ])
           )
-          it("has no schema", ->
+          it('has no schema', ->
             assert.isUndefined(compilationResult.transactions[i].response.schema)
           )
         )

--- a/test/integration/compile-test.coffee
+++ b/test/integration/compile-test.coffee
@@ -21,7 +21,7 @@ describe('compile() · all API description formats', ->
     fixtures.ordinary.forEachDescribe(({source}) ->
       compilationResult = undefined
 
-      beforeEach((done) ->
+      before((done) ->
         compileFixture(source, {filename}, (args...) ->
           [err, compilationResult] = args
           done(err)
@@ -38,7 +38,7 @@ describe('compile() · all API description formats', ->
     fixtures.parserError.forEachDescribe(({source}) ->
       compilationResult = undefined
 
-      beforeEach((done) ->
+      before((done) ->
         compileFixture(source, (args...) ->
           [err, compilationResult] = args
           done(err)
@@ -72,7 +72,7 @@ describe('compile() · all API description formats', ->
     fixtures.uriExpansionAnnotation.forEachDescribe(({source}) ->
       compilationResult = undefined
 
-      beforeEach((done) ->
+      before((done) ->
         compileFixture(source, (args...) ->
           [err, compilationResult] = args
           done(err)
@@ -110,7 +110,7 @@ describe('compile() · all API description formats', ->
     fixtures.uriValidationAnnotation.forEachDescribe(({source}) ->
       compilationResult = undefined
 
-      beforeEach((done) ->
+      before((done) ->
         compileFixture(source, (args...) ->
           [err, compilationResult] = args
           done(err)
@@ -152,7 +152,7 @@ describe('compile() · all API description formats', ->
     fixtures.parserWarning.forEachDescribe(({source}) ->
       compilationResult = undefined
 
-      beforeEach((done) ->
+      before((done) ->
         compileFixture(source, (args...) ->
           [err, compilationResult] = args
           done(err)
@@ -197,7 +197,7 @@ describe('compile() · all API description formats', ->
     fixtures.ordinary.forEachDescribe(({source}) ->
       compilationResult = undefined
 
-      beforeEach((done) ->
+      before((done) ->
         compileFixture(source, {stubs}, (args...) ->
           [err, compilationResult] = args
           done(err)
@@ -240,7 +240,7 @@ describe('compile() · all API description formats', ->
     fixtures.ambiguousParametersAnnotation.forEachDescribe(({source}) ->
       compilationResult = undefined
 
-      beforeEach((done) ->
+      before((done) ->
         compileFixture(source, (args...) ->
           [err, compilationResult] = args
           done(err)
@@ -281,7 +281,7 @@ describe('compile() · all API description formats', ->
     fixtures.ordinary.forEachDescribe(({source}) ->
       compilationResult = undefined
 
-      beforeEach((done) ->
+      before((done) ->
         compileFixture(source, {stubs}, (args...) ->
           [err, compilationResult] = args
           done(err)
@@ -315,7 +315,7 @@ describe('compile() · all API description formats', ->
     fixtures.enumParameter.forEachDescribe(({source}) ->
       compilationResult = undefined
 
-      beforeEach((done) ->
+      before((done) ->
         compileFixture(source, (args...) ->
           [err, compilationResult] = args
           done(err)
@@ -338,7 +338,7 @@ describe('compile() · all API description formats', ->
     fixtures.enumParameterExample.forEachDescribe(({source}) ->
       compilationResult = undefined
 
-      beforeEach((done) ->
+      before((done) ->
         compileFixture(source, (args...) ->
           [err, compilationResult] = args
           done(err)
@@ -367,7 +367,7 @@ describe('compile() · all API description formats', ->
     fixtures.enumParameterUnlistedExample.forEachDescribe(({source}) ->
       compilationResult = undefined
 
-      beforeEach((done) ->
+      before((done) ->
         compileFixture(source, (args...) ->
           [err, compilationResult] = args
           done(err)
@@ -402,7 +402,7 @@ describe('compile() · all API description formats', ->
     fixtures.exampleParameters.forEachDescribe(({source}) ->
       compilationResult = undefined
 
-      beforeEach((done) ->
+      before((done) ->
         compileFixture(source, (args...) ->
           [err, compilationResult] = args
           done(err)
@@ -425,7 +425,7 @@ describe('compile() · all API description formats', ->
     fixtures.responseSchema.forEachDescribe(({source}) ->
       compilationResult = undefined
 
-      beforeEach((done) ->
+      before((done) ->
         compileFixture(source, (args...) ->
           [err, compilationResult] = args
           done(err)
@@ -464,7 +464,7 @@ describe('compile() · all API description formats', ->
     fixtures.parametersInheritance.forEachDescribe(({source}) ->
       compilationResult = undefined
 
-      beforeEach((done) ->
+      before((done) ->
         compileFixture(source, (args...) ->
           [err, compilationResult] = args
           done(err)
@@ -487,7 +487,7 @@ describe('compile() · all API description formats', ->
     fixtures.preferDefault.forEachDescribe(({source}) ->
       compilationResult = undefined
 
-      beforeEach((done) ->
+      before((done) ->
         compileFixture(source, (args...) ->
           [err, compilationResult] = args
           done(err)
@@ -510,7 +510,7 @@ describe('compile() · all API description formats', ->
     fixtures.defaultRequired.forEachDescribe(({source}) ->
       compilationResult = undefined
 
-      beforeEach((done) ->
+      before((done) ->
         compileFixture(source, (args...) ->
           [err, compilationResult] = args
           done(err)
@@ -549,7 +549,7 @@ describe('compile() · all API description formats', ->
     fixtures.httpHeaders.forEachDescribe(({source}) ->
       compilationResult = undefined
 
-      beforeEach((done) ->
+      before((done) ->
         compileFixture(source, (args...) ->
           [err, compilationResult] = args
           done(err)
@@ -581,7 +581,7 @@ describe('compile() · all API description formats', ->
     fixtures.noBody.forEachDescribe(({source}) ->
       compilationResult = undefined
 
-      beforeEach((done) ->
+      before((done) ->
         compileFixture(source, (args...) ->
           [err, compilationResult] = args
           done(err)
@@ -609,7 +609,7 @@ describe('compile() · all API description formats', ->
       compilationResult = undefined
       expectedMediaTypes = ['application/json', 'application/json', 'text/csv', 'text/yaml']
 
-      beforeEach((done) ->
+      before((done) ->
         compileFixture(source, (args...) ->
           [err, compilationResult] = args
           done(err)

--- a/test/integration/compile-test.coffee
+++ b/test/integration/compile-test.coffee
@@ -706,12 +706,7 @@ describe('compile() · all API description formats', ->
   describe('without explicit schema', ->
     fixtures.noSchema.forEachDescribe(({source}) ->
       compilationResult = undefined
-      expectedMediaTypes = [
-        'application/json'
-        'application/json'
-        'text/csv'
-        'text/yaml'
-      ]
+      expectedMediaTypes = ['application/json', 'application/json', 'text/csv', 'text/yaml']
 
       beforeEach((done) ->
         compileFixture(source, (args...) ->
@@ -730,9 +725,9 @@ describe('compile() · all API description formats', ->
       expectedMediaTypes.forEach((mediaType, i) ->
         context("transaction ##{i + 1}", ->
           it("has '#{mediaType}' response", ->
-            assert.deepEqual(compilationResult.transactions[i].response.headers, {
-              'Content-Type': {value: mediaType}
-            })
+            assert.deepEqual(compilationResult.transactions[i].response.headers, [
+              {name: 'Content-Type', value: mediaType}
+            ])
           )
           it("has no schema", ->
             assert.isUndefined(compilationResult.transactions[i].response.schema)

--- a/test/integration/dredd-transactions-test.coffee
+++ b/test/integration/dredd-transactions-test.coffee
@@ -72,9 +72,9 @@ describe('Dredd Transactions', ->
       )
     )
 
-    it('produces one annotation, no transactions', ->
+    it('produces two annotations, no transactions', ->
       assert.jsonSchema(compilationResult, createCompilationResultSchema(
-        annotations: 1
+        annotations: 2
         transactions: 0
       ))
     )
@@ -83,6 +83,13 @@ describe('Dredd Transactions', ->
       assert.include(
         compilationResult.annotations[0].message,
         'to API Blueprint'
+      )
+    )
+    it('produces a warning about the API Blueprint not being valid', ->
+      assert.equal(compilationResult.annotations[1].type, 'warning')
+      assert.include(
+        compilationResult.annotations[1].message,
+        'expected'
       )
     )
   )
@@ -162,10 +169,10 @@ describe('Dredd Transactions', ->
         )
       )
 
-      it('produces some annotations, no transactions', ->
+      it('produces some annotations, some transactions', ->
         assert.jsonSchema(compilationResult, createCompilationResultSchema(
           annotations: true
-          transactions: 0
+          transactions: true
         ))
       )
       it('produces no errors', ->

--- a/test/schemas/annotation.coffee
+++ b/test/schemas/annotation.coffee
@@ -1,0 +1,36 @@
+createLocationSchema = require('./location')
+createOriginSchema = require('./origin')
+
+
+TYPES = ['error', 'warning']
+COMPONENTS = ['apiDescriptionParser', 'parametersValidation', 'uriTemplateExpansion']
+
+
+module.exports = (options = {}) ->
+  # Either filename string or undefined (= doesn't matter)
+  filename = options.filename
+
+  # options.message should be substring or RegExp
+  messageSchema = {type: 'string'}
+  messageSchema.pattern = options.message if options.message
+
+  {
+    type: 'object'
+    properties:
+      type:
+        type: 'string'
+        enum: if options.type then [options.type] else TYPES
+      component:
+        type: 'string'
+        enum: if options.component then [options.component] else COMPONENTS
+      message: messageSchema
+      location: createLocationSchema()
+      origin: createOriginSchema({filename})
+    required: ['type', 'component', 'message', 'location']
+    dependencies:
+      origin:
+        properties:
+          component:
+            enum: ['parametersValidation', 'uriTemplateExpansion']
+    additionalProperties: false
+  }

--- a/test/schemas/compilation-result.coffee
+++ b/test/schemas/compilation-result.coffee
@@ -36,7 +36,13 @@ module.exports = (options = {}) ->
         ]
       message: {type: 'string'}
       location: createLocationSchema()
+      origin: createOriginSchema({filename})
     required: ['type', 'component', 'message', 'location']
+    dependencies:
+      origin:
+        properties:
+          component:
+            enum: ['parametersValidation', 'uriTemplateExpansion']
     additionalProperties: false
 
   headersSchema =
@@ -79,12 +85,22 @@ module.exports = (options = {}) ->
     required: ['request', 'response', 'origin', 'name', 'pathOrigin', 'path']
     additionalProperties: false
 
+  transactionsSchema = addMinMax(
+    type: 'array'
+    items: transactionSchema
+  , transactions)
+
+  annotationsSchema = addMinMax(
+    type: 'array'
+    items: annotationSchema
+  , annotations)
+
   {
     type: 'object'
     properties:
       mediaType: {anyOf: [{type: 'string'}, {type: 'null'}]}
-      transactions: addMinMax({type: 'array', items: transactionSchema}, transactions)
-      annotations: addMinMax({type: 'array', items: annotationSchema}, annotations)
+      transactions: transactionsSchema
+      annotations: annotationsSchema
     required: ['mediaType', 'transactions', 'annotations']
     additionalProperties: false
   }

--- a/test/schemas/compilation-result.coffee
+++ b/test/schemas/compilation-result.coffee
@@ -29,18 +29,20 @@ module.exports = (options = {}) ->
   # will default to true (= structure must contain transaction names and paths)
   paths = if options.paths is false then false else true
 
+  headersSchema =
+    type: 'array'
+    items:
+      type: 'object'
+      properties:
+        name: {type: 'string'}
+        value: {type: 'string'}
+
   requestSchema =
     type: 'object'
     properties:
       uri: {type: 'string', pattern: '^/'}
       method: {type: 'string'}
-      headers:
-        type: 'object'
-        patternProperties:
-          '': # property of any name
-            type: 'object'
-            properties:
-              value: {type: 'string'}
+      headers: headersSchema
       body: {type: 'string'}
     required: ['uri', 'method', 'headers']
     additionalProperties: false
@@ -49,13 +51,7 @@ module.exports = (options = {}) ->
     type: 'object'
     properties:
       status: {type: 'string'}
-      headers:
-        type: 'object'
-        patternProperties:
-          '': # property of any name
-            type: 'object'
-            properties:
-              value: {type: 'string'}
+      headers: headersSchema
       body: {type: 'string'}
       schema: {type: 'string'}
     required: ['status', 'headers']

--- a/test/schemas/location.coffee
+++ b/test/schemas/location.coffee
@@ -1,4 +1,3 @@
-
 module.exports = ->
   {
     type: 'array'

--- a/test/schemas/origin.coffee
+++ b/test/schemas/origin.coffee
@@ -1,4 +1,3 @@
-
 module.exports = (options = {}) ->
   if options.filename
     filenameSchema = {type: 'string', enum: [options.filename]}

--- a/test/schemas/path-origin.coffee
+++ b/test/schemas/path-origin.coffee
@@ -1,4 +1,3 @@
-
 module.exports = ->
   {
     type: 'object'


### PR DESCRIPTION
- Includes https://github.com/apiaryio/dredd-transactions/pull/114
- Includes https://github.com/apiaryio/dredd-transactions/pull/107
- Additional commits deserving review:
  - c1ff38e: changes needed during rebasing
  - 16e6208: changes needed during rebasing
  - 589d6b2: using `before` instead of `beforeEach` for integration tests (API description parsing)
  - f7eaea2: using JSON Schema to (hopefully!) simplify assertions made on annotations

-------

Fixes #19, fixes #9. Related to apiaryio/dredd#356 and apiaryio/fury-adapter-swagger#129.