### PR TITLE
Decaff all the things Dredd, round three

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -58,7 +58,7 @@ function compileOriginExampleName(mediaType, httpResponseElement, exampleNo) {
       exampleName = `Example ${exampleNo}`;
     }
   } else {
-    const statusCode = (httpResponseElement.statusCode != null ? httpResponseElement.statusCode.toValue() : undefined) || '200';
+    const statusCode = (httpResponseElement.statusCode ? httpResponseElement.statusCode.toValue() : undefined) || '200';
     const headers = compileHeaders(httpResponseElement.headers);
 
     const contentType = headers
@@ -84,7 +84,7 @@ function compileOrigin(mediaType, filename, httpTransactionElement, exampleNo) {
   return {
     filename: filename || '',
     apiName: apiElement.meta.getValue('title') || filename || '',
-    resourceGroupName: (resourceGroupElement != null ? resourceGroupElement.meta.getValue('title') : undefined) || '',
+    resourceGroupName: (resourceGroupElement ? resourceGroupElement.meta.getValue('title') : undefined) || '',
     resourceName: resourceElement.meta.getValue('title') || resourceElement.attributes.getValue('href') || '',
     actionName: transitionElement.meta.getValue('title') || httpRequestElement.attributes.getValue('method') || '',
     exampleName: compileOriginExampleName(mediaType, httpResponseElement, exampleNo)
@@ -110,7 +110,7 @@ function compileRequest(httpRequestElement) {
       method: httpRequestElement.method.toValue(),
       uri,
       headers: compileHeaders(httpRequestElement.headers),
-      body: (httpRequestElement.messageBody != null ? httpRequestElement.messageBody.toValue() : undefined) || ''
+      body: (httpRequestElement.messageBody ? httpRequestElement.messageBody.toValue() : undefined) || ''
     };
   } else {
     request = null;
@@ -144,7 +144,7 @@ function compilePathOrigin(filename, httpTransactionElement, exampleNo) {
   const httpRequestElement = httpTransactionElement.request;
   return {
     apiName: apiElement.meta.getValue('title') || '',
-    resourceGroupName: (resourceGroupElement != null ? resourceGroupElement.meta.getValue('title') : undefined) || '',
+    resourceGroupName: (resourceGroupElement ? resourceGroupElement.meta.getValue('title') : undefined) || '',
     resourceName: resourceElement.meta.getValue('title') || resourceElement.attributes.getValue('href') || '',
     actionName: transitionElement.meta.getValue('title') || httpRequestElement.attributes.getValue('method') || '',
     exampleName: `Example ${exampleNo || 1}`

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ function compile(source, filename, callback) {
     // as it should be represented by annotation inside 'apiElements'
     // and compilation should be able to deal with it and to propagate it.
     let compilationResult;
-    if (!(parseResult != null ? parseResult.apiElements : undefined)) {
+    if (!(parseResult ? parseResult.apiElements : undefined)) {
       if (err) { return callback(null, createParserErrorCompilationResult(err.message)); }
 
       const message = 'The API description parser was unable to provide a valid parse result';

--- a/test/schemas/compilation-result.js
+++ b/test/schemas/compilation-result.js
@@ -22,7 +22,7 @@ module.exports = function createCompilationResultSchema(options = {}) {
 
   // Either exact number or interval ([1, 4] means 1 min, 4 max)
   const annotations = options.annotations || 0;
-  const transactions = (options.transactions != null) ? options.transactions : [1];
+  const transactions = options.transactions != null ? options.transactions : [1];
 
   const headersSchema = {
     type: 'array',

--- a/test/unit/compile-uri/validate-parameters-test.js
+++ b/test/unit/compile-uri/validate-parameters-test.js
@@ -227,7 +227,7 @@ describe('validateParams', () => {
       })
     );
 
-    return describe('and example value is not empty and default value is empty', () =>
+    describe('and example value is not empty and default value is empty', () =>
       it('should not set the error', () => {
         const params = {
           name: {
@@ -246,7 +246,7 @@ describe('validateParams', () => {
     );
   });
 
-  return describe('when parameter is not required', () => {
+  describe('when parameter is not required', () => {
     describe('and example and default value are empty', () =>
       it('should not set descirptive error', () => {
         const params = {
@@ -284,7 +284,7 @@ describe('validateParams', () => {
       })
     );
 
-    return describe('and example value is not empty and default value is empty', () =>
+    describe('and example value is not empty and default value is empty', () =>
       it('should not set the error', () => {
         const params = {
           name: {
@@ -303,4 +303,3 @@ describe('validateParams', () => {
     );
   });
 });
-

--- a/test/unit/parse-test.js
+++ b/test/unit/parse-test.js
@@ -27,7 +27,7 @@ describe('Parsing API description document', () => {
       it('produces API Elements', () => assert.isObject(apiElements));
       it('produces media type', () => assert.match(mediaType, reMediaType));
       it('the parse result is API Elements represented by minim objects', () => assert.instanceOf(apiElements, fury.minim.elements.ParseResult));
-      it('the parse result contains no annotation elements', () => assert.isTrue(apiElements.annotations != null ? apiElements.annotations.isEmpty : undefined));
+      it('the parse result contains no annotation elements', () => assert.isTrue(apiElements.annotations ? apiElements.annotations.isEmpty : undefined));
       it('the parse result contains source map elements', () => {
         const sourceMaps = apiElements
           .recursiveChildren
@@ -54,8 +54,8 @@ describe('Parsing API description document', () => {
       it('produces error', () => assert.instanceOf(error, Error));
       it('produces API Elements', () => assert.isObject(apiElements));
       it('produces media type', () => assert.match(mediaType, reMediaType));
-      it('the parse result contains annotation elements', () => assert.isFalse(apiElements.annotations != null ? apiElements.annotations.isEmpty : undefined));
-      it('the annotations are errors', () => assert.equal(apiElements.errors != null ? apiElements.errors.length : undefined, apiElements.annotations.length));
+      it('the parse result contains annotation elements', () => assert.isFalse(apiElements.annotations ? apiElements.annotations.isEmpty : undefined));
+      it('the annotations are errors', () => assert.equal(apiElements.errors ? apiElements.errors.length : undefined, apiElements.annotations.length));
     })
   );
 
@@ -76,8 +76,8 @@ describe('Parsing API description document', () => {
       it('produces no error', () => assert.isNull(error));
       it('produces API Elements', () => assert.isObject(apiElements));
       it('produces media type', () => assert.match(mediaType, reMediaType));
-      it('the parse result contains annotation elements', () => assert.isFalse(apiElements.annotations != null ? apiElements.annotations.isEmpty : undefined));
-      it('the annotations are warnings', () => assert.equal(apiElements.warnings != null ? apiElements.warnings.length : undefined, apiElements.annotations.length));
+      it('the parse result contains annotation elements', () => assert.isFalse(apiElements.annotations ? apiElements.annotations.isEmpty : undefined));
+      it('the annotations are warnings', () => assert.equal(apiElements.warnings ? apiElements.warnings.length : undefined, apiElements.annotations.length));
     })
   );
 
@@ -116,8 +116,8 @@ describe('Parsing API description document', () => {
     it('produces no error', () => assert.isNull(error));
     it('produces API Elements', () => assert.isObject(apiElements));
     it('produces media type', () => assert.match(mediaType, reMediaType));
-    it('the parse result contains annotation elements', () => assert.isFalse(apiElements.annotations != null ? apiElements.annotations.isEmpty : undefined));
-    it('the annotations are warnings', () => assert.equal(apiElements.warnings != null ? apiElements.warnings.length : undefined, apiElements.annotations.length));
+    it('the parse result contains annotation elements', () => assert.isFalse(apiElements.annotations ? apiElements.annotations.isEmpty : undefined));
+    it('the annotations are warnings', () => assert.equal(apiElements.warnings ? apiElements.warnings.length : undefined, apiElements.annotations.length));
     it('the first warning is about falling back to API Blueprint', () => assert.include(apiElements.warnings.getValue(0), 'to API Blueprint'));
   });
 
@@ -137,8 +137,8 @@ describe('Parsing API description document', () => {
     it('produces no error', () => assert.isNull(error));
     it('produces API Elements', () => assert.isObject(apiElements));
     it('produces media type', () => assert.match(mediaType, reMediaType));
-    it('the parse result contains annotation elements', () => assert.isFalse(apiElements.annotations != null ? apiElements.annotations.isEmpty : undefined));
-    it('the annotations are warnings', () => assert.equal(apiElements.warnings != null ? apiElements.warnings.length : undefined, apiElements.annotations.length));
+    it('the parse result contains annotation elements', () => assert.isFalse(apiElements.annotations ? apiElements.annotations.isEmpty : undefined));
+    it('the annotations are warnings', () => assert.equal(apiElements.warnings ? apiElements.warnings.length : undefined, apiElements.annotations.length));
     it('the first warning is about falling back to API Blueprint', () => assert.include(apiElements.warnings.getValue(0), 'to API Blueprint'));
   });
 });


### PR DESCRIPTION
Here goes third PR from the decaffenaite series.

### Notable changes:
- Unnecessary / forgotten `return`s and `if (something != null)` were cleaned-up

### To-Do:
- [ ] ~~Transform CommonJS module syntax to ES Modules syntax~~