### PR TITLE
Update Fury toolchain

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,9 +42,9 @@
   "dependencies": {
     "babel-polyfill": "^6.26.0",
     "clone": "^2.1.1",
-    "fury": "3.0.0-beta.4",
-    "fury-adapter-apib-parser": "0.9.0",
-    "fury-adapter-swagger": "0.15.2",
+    "fury": "3.0.0-beta.6",
+    "fury-adapter-apib-parser": "0.10.0",
+    "fury-adapter-swagger": "0.16.0",
     "uri-template": "^1.0.0"
   },
   "devDependencies": {

--- a/test/unit/compile-uri/compile-params-test.js
+++ b/test/unit/compile-uri/compile-params-test.js
@@ -155,9 +155,8 @@ describe('compileParams', () => {
 
   it('should compile an enum href variable', () => {
     const hrefVariables = new fury.minim.elements.HrefVariables();
-    const value = new fury.minim.elements.Element();
-    value.element = 'enum';
-    value.attributes.set('enumerations', ['ascending', 'decending']);
+    const value = new fury.minim.elements.Enum();
+    value.enumerations = ['ascending', 'decending'];
     hrefVariables.set('order', value);
 
     const parameters = compileParams(hrefVariables);
@@ -174,9 +173,8 @@ describe('compileParams', () => {
 
   it('should compile an enum href variable with values', () => {
     const hrefVariables = new fury.minim.elements.HrefVariables();
-    const value = new fury.minim.elements.Element('decending');
-    value.element = 'enum';
-    value.attributes.set('enumerations', ['ascending', 'decending']);
+    const value = new fury.minim.elements.Enum('decending');
+    value.enumerations = ['ascending', 'decending'];
     hrefVariables.set('order', value);
 
     const parameters = compileParams(hrefVariables);
@@ -193,10 +191,9 @@ describe('compileParams', () => {
 
   it('should compile an enum href variable with default', () => {
     const hrefVariables = new fury.minim.elements.HrefVariables();
-    const value = new fury.minim.elements.Element();
-    value.element = 'enum';
-    value.attributes.set('enumerations', ['ascending', 'decending']);
-    value.attributes.set('default', 'decending');
+    const value = new fury.minim.elements.Enum();
+    value.enumerations = ['ascending', 'decending'];
+    value.attributes.set('default', new fury.minim.elements.Enum('decending'));
     hrefVariables.set('order', value);
 
     const parameters = compileParams(hrefVariables);


### PR DESCRIPTION
These updates introduce a newer version of minim which updates some JSON Refract serialisation behaviour along with introducing an Enum Element class. There are changes to how default and sample values are represented inside an enum, as API Elements spec states that the types of these values should match the element type (enum) so that these values are now wrapped in an enum element. This doesn't change the behaviour in Dredd Transactions as `toValue` still works as expected.

I did update the tests to make use of the new enum element and update the structure.