### PR TITLE
Avoid loose deps and drop Node 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: "node_js"
 node_js:
-  - "4"
   - "6"
   - "8"
 addons:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 environment:
-  nodejs_version: "6"
+  nodejs_version: "8"
 install:
-  - ps: Install-Product node 6
-  - "npm -g install npm@latest"
+  - ps: Install-Product node 8
+  - "npm -g install npm@5"
   - "set PATH=%APPDATA%\\npm;%PATH%"
   - "npm install --no-optional"
 cache:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Compiles HTTP Transactions (Request-Response pairs) from API description document",
   "main": "dist/src/index.js",
   "engines": {
-    "node": ">= 4"
+    "node": ">= 6"
   },
   "scripts": {
     "build:source": "babel src --out-dir ./dist/src",
@@ -27,47 +27,37 @@
       "test/**/*.apib",
       "test/**/*.yml",
       "test/mocha.opts"
-    ],
-    "presets": [
-      [
-        "env",
-        {
-          "targets": {
-            "node": "4.0.0"
-          }
-        }
-      ]
     ]
   },
   "dependencies": {
-    "babel-polyfill": "^6.26.0",
-    "clone": "^2.1.1",
+    "babel-polyfill": "6.26.0",
+    "clone": "2.1.1",
     "fury": "3.0.0-beta.6",
     "fury-adapter-apib-parser": "0.10.0",
     "fury-adapter-swagger": "0.16.1",
-    "uri-template": "^1.0.0"
+    "uri-template": "1.0.0"
   },
   "devDependencies": {
-    "@commitlint/cli": "^4.2.1",
-    "@commitlint/config-angular": "^4.2.1",
-    "babel-cli": "^6.26.0",
-    "babel-core": "^6.26.0",
-    "babel-preset-env": "^1.6.1",
-    "chai": "^4.1.0",
-    "chai-json-schema": "^1.3.0",
-    "coveralls": "^2.13.1",
-    "drafter": "^1.0.0",
-    "eslint": "^4.4.1",
-    "eslint-config-airbnb": "^15.1.0",
-    "eslint-plugin-import": "^2.7.0",
-    "istanbul": "^0.4.5",
-    "mocha": "^4.0.1",
-    "mocha-lcov-reporter": "^1.3.0",
-    "proxyquire": "^1.8.0",
-    "rimraf": "^2.6.2",
-    "semantic-release": "^8.2.0",
-    "sinon": "^4.0.1",
-    "swagger-zoo": "^2.5.2"
+    "@commitlint/cli": "4.2.1",
+    "@commitlint/config-angular": "4.2.1",
+    "babel-cli": "6.26.0",
+    "babel-core": "6.26.0",
+    "babel-preset-env": "1.6.1",
+    "chai": "4.1.0",
+    "chai-json-schema": "1.3.0",
+    "coveralls": "2.13.1",
+    "drafter": "1.0.0",
+    "eslint": "4.4.1",
+    "eslint-config-airbnb": "15.1.0",
+    "eslint-plugin-import": "2.7.0",
+    "istanbul": "0.4.5",
+    "mocha": "4.0.1",
+    "mocha-lcov-reporter": "1.3.0",
+    "proxyquire": "1.8.0",
+    "rimraf": "2.6.2",
+    "semantic-release": "8.2.0",
+    "sinon": "4.0.1",
+    "swagger-zoo": "2.5.2"
   },
   "keywords": [
     "api",


### PR DESCRIPTION
**BREAKING CHANGE:** From this release, Dredd Transactions are not tested on Node 4 anymore.
Node 4 end of life is April 2018. 

(We will use the Babel presets later on to support browsers, though.)