### PR TITLE
Bump uri-template and remove babel-polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "fury": "3.0.0-beta.6",
     "fury-adapter-apib-parser": "0.10.0",
     "fury-adapter-swagger": "0.16.1",
-    "uri-template": "1.0.0"
+    "uri-template": "^1.0.1"
   },
   "devDependencies": {
     "@commitlint/cli": "4.2.1",

--- a/package.json
+++ b/package.json
@@ -30,12 +30,11 @@
     ]
   },
   "dependencies": {
-    "babel-polyfill": "6.26.0",
     "clone": "2.1.1",
     "fury": "3.0.0-beta.6",
     "fury-adapter-apib-parser": "0.10.0",
     "fury-adapter-swagger": "0.16.1",
-    "uri-template": "^1.0.1"
+    "uri-template": "1.0.1"
   },
   "devDependencies": {
     "@commitlint/cli": "4.2.1",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,3 @@
-require('babel-polyfill');
-
 const parse = require('./parse');
 const compileFromApiElements = require('./compile');
 


### PR DESCRIPTION
- `uri-template` was effectively downgraded in #145 
- `babel-polyfill` is not needed since all features used in this package are supported by Node.js 6 (did not test 4). It's also a bad practice to load it in a library as it modifies globals.