### PR TITLE
fix: don't ignore "0" example value

### DIFF
--- a/src/compile-uri/compile-params.js
+++ b/src/compile-uri/compile-params.js
@@ -8,10 +8,11 @@ module.exports = function compileParams(hrefVariablesElement) {
     const typeAttributes = memberElement.attributes.getValue('typeAttributes') || [];
     const values = valueElement.attributes.getValue('enumerations') || [];
 
+    const example = valueElement.toValue();
     params[name] = {
       required: Array.from(typeAttributes).includes('required'),
       default: valueElement.attributes.getValue('default'),
-      example: valueElement.toValue() || values[0],
+      example: typeof example === 'undefined' || example === null ? values[0] : example,
       values
     };
 

--- a/src/compile-uri/expand-uri-template.js
+++ b/src/compile-uri/expand-uri-template.js
@@ -45,9 +45,9 @@ Parameter not defined in API description document: ${uriParameter}\
       uriParameters.forEach((uriParameter) => {
         param = params[uriParameter];
 
-        if ('example' in param) {
+        if (typeof param.example !== 'undefined' && param.example !== '') {
           toExpand[uriParameter] = param.example;
-        } else if ('default' in param) {
+        } else if (typeof param.default !== 'undefined' && param.default !== '') {
           toExpand[uriParameter] = param.default;
         } else if (param.required) {
           ambiguous = true;
@@ -58,7 +58,7 @@ document: ${uriParameter}\
 `);
         }
 
-        if (param.required && 'default' in param) {
+        if (param.required && typeof param.default !== 'undefined' && param.default !== '') {
           result.warnings.push(`\
 Required URI parameter '${uriParameter}' has a default value.
 Default value for a required parameter doesn't make sense from \

--- a/src/compile-uri/expand-uri-template.js
+++ b/src/compile-uri/expand-uri-template.js
@@ -45,9 +45,9 @@ Parameter not defined in API description document: ${uriParameter}\
       uriParameters.forEach((uriParameter) => {
         param = params[uriParameter];
 
-        if (param.example) {
+        if ('example' in param) {
           toExpand[uriParameter] = param.example;
-        } else if (param.default) {
+        } else if ('default' in param) {
           toExpand[uriParameter] = param.default;
         } else if (param.required) {
           ambiguous = true;
@@ -58,7 +58,7 @@ document: ${uriParameter}\
 `);
         }
 
-        if (param.required && param.default) {
+        if (param.required && 'default' in param) {
           result.warnings.push(`\
 Required URI parameter '${uriParameter}' has a default value.
 Default value for a required parameter doesn't make sense from \

--- a/src/compile-uri/validate-params.js
+++ b/src/compile-uri/validate-params.js
@@ -5,7 +5,7 @@ module.exports = function validateParams(params) {
     let text;
     const param = params[paramName];
 
-    if (param.required && !param.example && !param.default) {
+    if (param.required && !('example' in param) && !('default' in param)) {
       text = `Required URI parameter '${paramName}' has no example or default value.`;
       result.errors.push(text);
     }

--- a/src/compile-uri/validate-params.js
+++ b/src/compile-uri/validate-params.js
@@ -5,7 +5,7 @@ module.exports = function validateParams(params) {
     let text;
     const param = params[paramName];
 
-    if (param.required && !('example' in param) && !('default' in param)) {
+    if (param.required && !(typeof param.example !== 'undefined' && param.example !== '') && !(typeof param.default !== 'undefined' && param.default !== '')) {
       text = `Required URI parameter '${paramName}' has no example or default value.`;
       result.errors.push(text);
     }


### PR DESCRIPTION
If some API's parameter has an "example" value of 0, currently it is ignored and dredd prints error mesages like "Required URI parameter * has no example or default value".

This PR is to fix this behavior.