### PR TITLE
Do not modify the lock file on CI installs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ cache:
 before_install:
   - "npm -g install npm@6"
 install:
-  - "if [[ $DRAFTER = JS ]]; then npm install --no-optional; else npm install; fi"
+  - "if [[ $DRAFTER = JS ]]; then npm install --no-optional --no-save; else npm install --no-save; fi"
 script:
   - "npm run ci:test"
 after_success:


### PR DESCRIPTION
Recently I'm getting Travis CI jobs failing because the package-lock.json gets modified during the installation and then it fails to do git manipulations as there are unstaged changes which would be "lost".

I'm trying to add `--no-save` to mitigate the problem. It helped in https://github.com/apiaryio/dredd/pull/1151/commits/23cc1645c3bbe4a95492a7486b28031fa01b273a, but so temporarily did some random changes to the Travis CI config in the past... 🙄 Hopefully this is gonna work permanently.