### PR TITLE
Provide location of annotations as a range of line and column numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,15 +152,18 @@ Description of an error or warning which occurred during parsing of the API desc
 - type (enum[string])
     - `error`
     - `warning`
-- component (enum[string]) - In which component of the compilation process the annotation occurred.
+- component (enum[string]) - In which component of the compilation process the annotation occurred
     - `apiDescriptionParser`
     - `parametersValidation`
     - `uriTemplateExpansion`
-- message (string) - Textual annotation. This is – in most cases – a human-readable message to be displayed to user.
-- location (array) - Locations of the annotation in the source file. A series of character-blocks, which may be non-continuous. For further details refer to API Elements' [Source Map](source-map) element.
-    - (array, fixed) - Continuous characters block. A pair of character index and character count.
-        - (number) - Zero-based index of a character in the source document.
-        - (number) - Count of characters starting from the character index.
+- message (string) - Textual annotation. This is – in most cases – a human-readable message to be displayed to user
+- location (array, fixed, nullable) - Location of the annotation in the source file, represented by a single range of line and column number pairs if available, or by `null` otherwise
+    - (array) - Start location
+        - (number) - Line number
+        - (number) - Column number
+    - (array) - End location
+        - (number) - Line number
+        - (number) - Column number
 
 ### Deprecated Properties
 

--- a/compile/compileAnnotation.js
+++ b/compile/compileAnnotation.js
@@ -1,8 +1,28 @@
+function compileLocation(sourceMapElement) {
+  try {
+    const startAttributes = sourceMapElement.first.first.first.attributes;
+    const endAttributes = sourceMapElement.last.last.last.attributes;
+    return [
+      [
+        startAttributes.get('line').toValue(),
+        startAttributes.get('column').toValue(),
+      ],
+      [
+        endAttributes.get('line').toValue(),
+        endAttributes.get('column').toValue(),
+      ],
+    ];
+  } catch (e) {
+    return null;
+  }
+}
+
+
 module.exports = function compileAnnotation(annotationElement) {
   return {
     type: annotationElement.classes.getValue(0),
     component: 'apiDescriptionParser',
     message: annotationElement.toValue(),
-    location: annotationElement.sourceMapValue || [[0, 1]],
+    location: compileLocation(annotationElement.attributes.get('sourceMap')),
   };
 };

--- a/compile/compileAnnotation.js
+++ b/compile/compileAnnotation.js
@@ -1,0 +1,8 @@
+module.exports = function compileAnnotation(annotationElement) {
+  return {
+    type: annotationElement.classes.getValue(0),
+    component: 'apiDescriptionParser',
+    message: annotationElement.toValue(),
+    location: annotationElement.sourceMapValue || [[0, 1]],
+  };
+};

--- a/compile/index.js
+++ b/compile/index.js
@@ -1,6 +1,7 @@
 const detectTransactionExampleNumbers = require('./detectTransactionExampleNumbers');
 const compileUri = require('./compileURI');
 const compileTransactionName = require('./compileTransactionName');
+const compileAnnotation = require('./compileAnnotation');
 
 
 function findRelevantTransactions(mediaType, apiElements) {
@@ -164,15 +165,6 @@ function compileTransaction(mediaType, filename, httpTransactionElement, example
     request, response, origin, name,
   };
   return { transaction, annotations };
-}
-
-function compileAnnotation(annotationElement) {
-  return {
-    type: annotationElement.classes.getValue(0),
-    component: 'apiDescriptionParser',
-    message: annotationElement.toValue(),
-    location: annotationElement.sourceMapValue || [[0, 1]],
-  };
 }
 
 function compile(mediaType, apiElements, filename) {

--- a/test/fixtures/apib/annotation-sourcemap-ranges.apib
+++ b/test/fixtures/apib/annotation-sourcemap-ranges.apib
@@ -1,0 +1,9 @@
+# API Name
+
+## GET /
+
++ Response 200 (application/json)
+    + Headers
+
+        One: Two
+        Three: Four

--- a/test/fixtures/openapi3/parser-warning.yml
+++ b/test/fixtures/openapi3/parser-warning.yml
@@ -1,0 +1,12 @@
+openapi: "3.0.0"
+info:
+  version: "1.0.0"
+  title: Title
+paths:
+  /:
+    get:
+      summary: Summary
+      foo: {}
+      responses:
+        "200":
+          description: "Success"

--- a/test/schemas/createLocationSchema.js
+++ b/test/schemas/createLocationSchema.js
@@ -1,11 +1,21 @@
-module.exports = () => ({
+const position = {
   type: 'array',
-  items: {
-    type: 'array',
-    items: [
-      { type: 'number' },
-      { type: 'number' },
-    ],
-    additionalItems: false,
-  },
+  items: [
+    { type: 'number' },
+    { type: 'number' },
+  ],
+  additionalItems: false,
+};
+
+module.exports = () => ({
+  anyOf: [
+    {
+      type: 'array',
+      items: [position, position],
+      additionalItems: false,
+    },
+    {
+      type: 'null',
+    },
+  ],
 });

--- a/test/unit/compileAnnotation-test.js
+++ b/test/unit/compileAnnotation-test.js
@@ -1,6 +1,6 @@
 const fury = require('fury');
-const { assert } = require('chai');
 
+const { assert, fixtures } = require('../support');
 const compileAnnotation = require('../../compile/compileAnnotation');
 
 
@@ -32,5 +32,45 @@ describe('compileAnnotation()', () => {
     const annotation = compileAnnotation(annotationElement);
 
     assert.propertyVal(annotation, 'message', 'Ouch!');
+  });
+  it('sets location to [[start row, column], [end row, column]]', () => {
+    const { apiElements } = fixtures('parser-warning').apib;
+    const annotation = compileAnnotation(apiElements.annotations.first);
+
+    assert.deepPropertyVal(annotation, 'location', [[7, 3], [8, 1]]);
+  });
+  it('sets location to null for no source maps', () => {
+    const annotationElement = new Annotation('Ouch!');
+    const annotation = compileAnnotation(annotationElement);
+
+    assert.isNull(annotation.location);
+  });
+  it('sets location to the extreme positions for multiple ranges', () => {
+    const { apiElements } = fixtures('annotation-sourcemap-ranges').apib;
+    const annotation = compileAnnotation(apiElements.annotations.first);
+
+    assert.deepPropertyVal(annotation, 'location', [[8, 9], [9, 20]]);
+  });
+
+  fixtures('parser-warning').forEachDescribe(({ apiElements }) => {
+    const { location } = compileAnnotation(apiElements.annotations.first);
+
+    it('sets location in the expected format', () => {
+      assert.isArray(location);
+      assert.equal(location.length, 2);
+
+      assert.isArray(location[0]);
+      assert.equal(location[0].length, 2);
+      assert.isNumber(location[0][0]);
+      assert.isNumber(location[0][1]);
+
+      assert.isArray(location[1]);
+      assert.equal(location[1].length, 2);
+      assert.isNumber(location[1][0]);
+      assert.isNumber(location[1][1]);
+    });
+    it('has the first row number ≦ second row number', () => {
+      assert.isAtMost(location[0][0], location[1][0]);
+    });
   });
 });

--- a/test/unit/compileAnnotation-test.js
+++ b/test/unit/compileAnnotation-test.js
@@ -1,0 +1,36 @@
+const fury = require('fury');
+const { assert } = require('chai');
+
+const compileAnnotation = require('../../compile/compileAnnotation');
+
+
+describe('compileAnnotation()', () => {
+  const { Annotation } = fury.minim.elements;
+
+  it('sets the type to error for error annotations', () => {
+    const annotationElement = new Annotation('Ouch!');
+    annotationElement.classes.push('error');
+    const annotation = compileAnnotation(annotationElement);
+
+    assert.propertyVal(annotation, 'type', 'error');
+  });
+  it('sets the type to warning for warning annotations', () => {
+    const annotationElement = new Annotation('Ouch!');
+    annotationElement.classes.push('warning');
+    const annotation = compileAnnotation(annotationElement);
+
+    assert.propertyVal(annotation, 'type', 'warning');
+  });
+  it('sets the source component of the annotation to parser', () => {
+    const annotationElement = new Annotation('Ouch!');
+    const annotation = compileAnnotation(annotationElement);
+
+    assert.propertyVal(annotation, 'component', 'apiDescriptionParser');
+  });
+  it('sets message of the annotation', () => {
+    const annotationElement = new Annotation('Ouch!');
+    const annotation = compileAnnotation(annotationElement);
+
+    assert.propertyVal(annotation, 'message', 'Ouch!');
+  });
+});


### PR DESCRIPTION
Enables apiaryio/dredd#1191, apiaryio/dredd#916, apiaryio/dredd#127

**BREAKING CHANGE:** The 'location' property of annotations will now have a different format - a range of line and column numbers, correctly pre-calculated by the individual API description parsers