### PR TITLE
Fix: Support dotted query parameter

### DIFF
--- a/compile/compileURI/expandURItemplate.js
+++ b/compile/compileURI/expandURItemplate.js
@@ -21,7 +21,8 @@ Error: ${e}\
   // Get parameters from expression object
   const uriParameters = parsed.expressions
     .map(expression => expression.params.map(param => param.name))
-    .reduce((accumulator, current) => accumulator.concat(current), []);
+    .reduce((accumulator, current) => accumulator.concat(current), [])
+    .map(decodeURI);
 
   if (parsed.expressions.length === 0) {
     result.uri = uriTemplate;

--- a/test/fixtures/openapi2/dotted-query-parameters.yml
+++ b/test/fixtures/openapi2/dotted-query-parameters.yml
@@ -1,0 +1,26 @@
+swagger: "2.0"
+
+info:
+  version: '1'
+  title: test
+
+host: petstore.swagger.io
+basePath: /api
+
+schemes:
+  - http
+
+consumes:
+  - application/json
+
+paths:
+  /pets:
+    get:
+      description: Get
+      parameters:
+        - in: query
+          name: filter.dotted
+          type: string
+      responses:
+        '200':
+          description: OK

--- a/test/integration/compile-test.js
+++ b/test/integration/compile-test.js
@@ -201,6 +201,19 @@ describe('compile() · all API description formats', () => {
     });
   });
 
+  describe('with dotted query parameters', () => {
+    fixtures('dotted-query-parameters').forEachDescribe(({ mediaType, apiElements }) => {
+      const compileResult = compile(mediaType, apiElements);
+
+      it('produces no annotations and one transactions', () => {
+        assert.jsonSchema(compileResult, createCompileResultSchema({
+          annotations: 0,
+          transactions: 1,
+        }));
+      });
+    });
+  });
+
   describe('causing a warning in URI parameters validation', () => {
     // Since 'validateParams' doesn't actually return any warnings
     // (but could in the future), we need to pretend it's possible for this


### PR DESCRIPTION
It is expected to be able to have dot(s) (special characters) in the query parameter.

This fix will decode URI parameters and then check for ambiguous possibilities.

Fixes the following issue:
https://github.com/apiaryio/dredd/issues/1256
