### PR TITLE
Provide transaction name for each annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Description of an error or warning which occurred during parsing of the API desc
 
 ### Deprecated Properties
 
+- name: `Hello world! > Retrieve Message` (string) - Transaction Name, non-deterministic breadcrumb location of the relevant HTTP Transaction within the API description document.
 - origin (object) - Object of references to nodes of [API Elements][api-elements] derived from the original API description document.
     - filename: `./api-description.apib` (string)
     - apiName: `My Api` (string)

--- a/compile/compileTransactionName.js
+++ b/compile/compileTransactionName.js
@@ -1,9 +1,11 @@
 module.exports = function compileTransactionName(origin) {
-  const segments = [];
-  if (origin.apiName) { segments.push(origin.apiName); }
-  if (origin.resourceGroupName) { segments.push(origin.resourceGroupName); }
-  if (origin.resourceName) { segments.push(origin.resourceName); }
-  if (origin.actionName) { segments.push(origin.actionName); }
-  if (origin.exampleName) { segments.push(origin.exampleName); }
-  return segments.join(' > ');
+  return [
+    origin.apiName,
+    origin.resourceGroupName,
+    origin.resourceName,
+    origin.actionName,
+    origin.exampleName,
+  ]
+    .filter(Boolean)
+    .join(' > ');
 };


### PR DESCRIPTION
See each commit on which particular issue it is addressing. This enables us to delete a redundant file in Dredd's codebase.

I had to change JSON Schema generated for tests of this library. Previously it was using an advanced JSON Schema concept called "dependencies" to distinguish between the specifics of parse annotations and compile annotations. I found out this wasn't working and the validation skipped it every time, so the specifics of each annotation were left untested. I changed the schema so it uses `anyOf` instead, with two distinct specific sub-schemas, one for parse annotation and the other one for compile annotation. This now correctly validates structure of each annotation tested.

I did not bother with refactoring the code, removing mutations, etc. I only did surgical changes. I also did not remove `origin` property from the annotations, although it's practically unneeded now, because I didn't want to introduce a breaking change. Both `name` and `origin` can be removed once we figure out https://github.com/apiaryio/dredd-transactions/issues/275