### PR TITLE
Update fury to 3.0.0-beta.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
     "README.md"
   ],
   "dependencies": {
-    "fury": "3.0.0-beta.10",
-    "fury-adapter-apib-parser": "0.14.0",
-    "fury-adapter-oas3-parser": "0.7.7",
-    "fury-adapter-swagger": "0.25.1",
+    "fury": "3.0.0-beta.11",
+    "fury-adapter-apib-parser": "0.15.0",
+    "fury-adapter-oas3-parser": "0.8.0",
+    "fury-adapter-swagger": "0.26.0",
     "uri-template": "1.0.1"
   },
   "bundledDependencies": [


### PR DESCRIPTION
Fury 3.0.0-beta.11 drops support for Node 6. There are a few bug fixes in the relevant parsers which I believe can close out some open Dredd issues.

- https://github.com/apiaryio/api-elements.js/releases/tag/fury-adapter-swagger%400.26.0
- https://github.com/apiaryio/api-elements.js/releases/tag/fury-adapter-oas3-parser%400.8.0