### PR TITLE
Update fury to 3.0.0-beta.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
     "README.md"
   ],
   "dependencies": {
-    "fury": "3.0.0-beta.11",
-    "fury-adapter-apib-parser": "0.15.0",
-    "fury-adapter-oas3-parser": "0.8.1",
-    "fury-adapter-swagger": "0.26.0",
+    "fury": "3.0.0-beta.12",
+    "fury-adapter-apib-parser": "0.16.0",
+    "fury-adapter-oas3-parser": "0.9.0",
+    "fury-adapter-swagger": "0.27.0",
     "uri-template": "1.0.1"
   },
   "bundledDependencies": [


### PR DESCRIPTION
Mostly brings performance improvements to parsing OAS 3 documents