### PR TITLE
Fix test fixture for the multi range example

### DIFF
--- a/test/fixtures/apib/annotation-sourcemap-ranges.apib
+++ b/test/fixtures/apib/annotation-sourcemap-ranges.apib
@@ -3,7 +3,11 @@
 ## GET /
 
 + Response 200 (application/json)
-    + Headers
 
-        One: Two
-        Three: Four
+        + Body
+
+                {}
+
+        + Schema
+
+                {}

--- a/test/unit/compileAnnotation-test.js
+++ b/test/unit/compileAnnotation-test.js
@@ -47,9 +47,14 @@ describe('compileAnnotation()', () => {
   });
   it('sets location to the extreme positions for multiple ranges', () => {
     const { apiElements } = fixtures('annotation-sourcemap-ranges').apib;
-    const annotation = compileAnnotation(apiElements.annotations.first);
+    const annotationElement = apiElements.annotations.first;
 
-    assert.deepPropertyVal(annotation, 'location', [[8, 9], [9, 20]]);
+    // verify that there truly are multiple ranges - the parser could change implementation
+    assert.isAbove(annotationElement.attributes.get('sourceMap').first.toValue().length, 1);
+
+    const annotation = compileAnnotation(annotationElement);
+
+    assert.deepPropertyVal(annotation, 'location', [[7, 5], [13, 19]]);
   });
 
   fixtures('parser-warning').forEachDescribe(({ apiElements }) => {


### PR DESCRIPTION
Context is explained in https://github.com/apiaryio/dredd-transactions/issues/348. The example used for testing multiple-ranged souce maps for annotation stopped to produce multiple ranges after [Drafter 4.0.1](https://github.com/apiaryio/drafter/releases/tag/v4.0.1) has been released and propagated through vaguely pinned transitive dependencies.

I've used a trick from this [API Blueprint](https://raw.githubusercontent.com/apiaryio/drafter/45c1cc4538c6be51bfef8d4259f06030f5112b07/test/fixtures/api/issue-702.apib) suggested by @kylef, which serves for producing multiple ranges in the Drafter's test suite.

The test verifies that code normalizes the range to boundary positions:

```js
assert.deepPropertyVal(annotation, 'location', [[7, 5], [13, 19]]);
```

The ones I hardcoded to the test are verified manually through VS Code. On the screenshots below you can see how my cursor position translates to line and column numbers in VS Code's blue bottom bar:

<img width="1185" alt="Screenshot 2019-10-01 at 15 19 29" src="https://user-images.githubusercontent.com/283441/65965482-fcbfd580-e45e-11e9-96be-4200f4175226.png">

<img width="1163" alt="Screenshot 2019-10-01 at 15 18 38" src="https://user-images.githubusercontent.com/283441/65965503-047f7a00-e45f-11e9-9358-723a114efe66.png">
